### PR TITLE
Add automated Windows builds with AppVeyor

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -2,8 +2,12 @@
 
 Generally speaking, `docker-compose` and Docker Engine are a work in
 progress on Windows. We have highly experimental Windows support in `cage`
-for people who want to try it out and let us know about any issues.  **But
-be warned!** Not all the test suites pass yet.
+for people who want to try it out and let us know about any issues.
+
+**But be warned!** Not all the test suites pass yet.  For an overview of
+the current unit test status, click on the AppVeyor build badge below:
+
+[![AppVeyor](https://img.shields.io/appveyor/ci/emk/cage.svg)](https://ci.appveyor.com/project/emk/cage)
 
 This document should give you all the information you need on available
 builds and overall guidance when working with `cage` on Windows.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,4 +9,5 @@ install:
 build: false
 
 test_script:
-  - cargo test --verbose --no-default-features --feature default-minimal
+  - cargo build --verbose --no-default-features --features default-minimal
+  - cargo test --verbose --no-default-features --features default-minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+install:
+  - ps: Start-FileDownload "https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe"
+  - rustup-init.exe -y --default-host i686-pc-windows-gnu
+  - SET PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - SET PATH=%PATH%;C:\MinGW\bin
+  - rustc -V
+  - cargo -V
+
+build:
+  - cargo build --verbose --no-default-features --feature default-minimal
+
+test_script:
+  - cargo test --verbose --no-default-features --feature default-minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,7 @@ install:
   - rustc -V
   - cargo -V
 
-build:
-  - cargo build --verbose --no-default-features --feature default-minimal
+build: false
 
 test_script:
   - cargo test --verbose --no-default-features --feature default-minimal


### PR DESCRIPTION
This will allow non-Windows developers to at least see which unit tests, etc., are broken on Windows.