### PR TITLE
`up --init`: Initialize containers at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ dependencies = [
  "clippy 0.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "compose_yml 0.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docker 0.0.41 (git+https://github.com/faradayio/rust-docker?branch=update_and_port)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -18,6 +19,7 @@ dependencies = [
  "phf 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -177,6 +179,19 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "docker"
+version = "0.0.41"
+source = "git+https://github.com/faradayio/rust-docker?branch=update_and_port#8cf4ad20e1f09372797aaf1f07f8fc81653ec45d"
+dependencies = [
+ "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "named_pipe 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -381,6 +396,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "named_pipe"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -861,6 +885,15 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unix_socket"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "url"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1614659040e711785ed8ea24219140654da1729f3ec8a47a9719d041112fe7bf"
+"checksum docker 0.0.41 (git+https://github.com/faradayio/rust-docker?branch=update_and_port)" = "<none>"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"
 "checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
@@ -958,6 +992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5c93a4bd787ddc6e7833c519b73a50883deb5863d76d9b71eb8216fb7f94e66"
 "checksum miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d1f4d337a01c32e1f2122510fed46393d53ca35a7f429cb0450abaedfa3ed54"
+"checksum named_pipe 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "57495d00ae2cf44c03e8cd9246f9a00eb803e63e9664ff61b5cc288c328ca9b8"
 "checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 "checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
 "checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
@@ -1019,6 +1054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b905d0fc2a1f0befd86b0e72e31d1787944efef9d38b9358a9e92a69757f7e3b"
 "checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
 "checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
+"checksum unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"
 "checksum url 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ba5a45db1d2e0effb7a1c00cc73ffc63a973da8c7d1fcd5b46f24285ade6c54"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 [[package]]
 name = "docker"
 version = "0.0.41"
-source = "git+https://github.com/faradayio/rust-docker?branch=update_and_port#8cf4ad20e1f09372797aaf1f07f8fc81653ec45d"
+source = "git+https://github.com/faradayio/rust-docker?branch=update_and_port#c3cf56749d69c7a951ba80ec9e269564c79eba01"
 dependencies = [
  "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,11 @@
 name = "cage"
 version = "0.1.6"
 dependencies = [
+ "boondock 0.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "compose_yml 0.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "docker 0.0.41 (git+https://github.com/faradayio/rust-docker?branch=update_and_port)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -72,6 +72,19 @@ dependencies = [
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "boondock"
+version = "0.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "named_pipe 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cfg-if"
@@ -179,19 +192,6 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "docker"
-version = "0.0.41"
-source = "git+https://github.com/faradayio/rust-docker?branch=update_and_port#c3cf56749d69c7a951ba80ec9e269564c79eba01"
-dependencies = [
- "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "named_pipe 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -956,6 +956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "346d7644f0b5f9bc73082d3b2236b69a05fd35cce0cfa3724e184e6a5c9e2a2f"
 "checksum backtrace-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ff73785ae8e06bb4a7b09e09f06d7434f9748b86d2f67bdf334b603354497e08"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum boondock 0.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "dc5b92dc1760057f4e15275b36761518b3c9b74e37643864bf7b2b937808d4f6"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum clap 2.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c3ad95014a5d1926493801463817b2e7e3ee64e051361a560f805c5320cd17b1"
@@ -966,7 +967,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1614659040e711785ed8ea24219140654da1729f3ec8a47a9719d041112fe7bf"
-"checksum docker 0.0.41 (git+https://github.com/faradayio/rust-docker?branch=update_and_port)" = "<none>"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"
 "checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ unstable = ["unstable-minimal", "openssl", "clippy"]
 # So we allow it to be disabled using:
 #
 #     cargo build --no-default-features --features default_minimal
-openssl = ["hashicorp_vault"]
+openssl = ["hashicorp_vault", "boondock/ssl"]
 
 # You must always enable one of these features or the other to get serde to
 # build.
@@ -42,11 +42,11 @@ includedir_codegen = "0.2.1"
 serde_codegen = { version = "0.8", optional = true }
 
 [dependencies]
+boondock = { version = "0.0.43", default-features = false }
 clap = { version = "2.14.0", features = ["yaml"] }
 clippy = { version = "0.0.*", optional = true }
 colored = "1.3.1"
 compose_yml = { version = "0.0.45", default-features = false }
-docker = { git = "https://github.com/faradayio/rust-docker", branch = "update_and_port" }
 env_logger = "0.3.4"
 error-chain = "0.5.0"
 glob = "0.2.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ clap = { version = "2.14.0", features = ["yaml"] }
 clippy = { version = "0.0.*", optional = true }
 colored = "1.3.1"
 compose_yml = { version = "0.0.45", default-features = false }
+docker = { git = "https://github.com/faradayio/rust-docker", branch = "update_and_port" }
 env_logger = "0.3.4"
 error-chain = "0.5.0"
 glob = "0.2.11"
@@ -57,6 +58,7 @@ log = "0.3.6"
 phf = "0.7.16"
 rand = "0.3.14"
 rayon = "0.4.2"
+regex = "0.1.73"
 retry = "0.4.0"
 rustc-serialize = "0.3.19"
 semver = "0.5.0"

--- a/data/templates/new/pods/db.metadata.yml
+++ b/data/templates/new/pods/db.metadata.yml
@@ -9,3 +9,10 @@ pod_type: "placeholder"
 # `"test"` to this list.
 enable_in_targets:
 - "development"
+
+# A list of commands to run automatically when `cage up --init` is called
+# on this pod.  These behave as though passed to `cage run`, so the first
+# argument must be the name of a pod or a service.
+run_on_init:
+- ["rake", "db:create"]
+- ["rake", "db:migrate"]

--- a/data/templates/new/pods/db.metadata.yml
+++ b/data/templates/new/pods/db.metadata.yml
@@ -14,5 +14,10 @@ enable_in_targets:
 # on this pod.  These behave as though passed to `cage run`, so the first
 # argument must be the name of a pod or a service.
 run_on_init:
+# Cage makes sure that PostgreSQL is listening on the expected port, but
+# even once the port is open, we may need to wait longer while it finishes
+# disk recovery.  We can run do this by running a script in the `db` pod.
+- ["db", "bash", "-c", "while ! pg_isready -q -h db; do sleep 0.25; done"]
+# Use the `rake` pod to create our database.
 - ["rake", "db:create"]
 - ["rake", "db:migrate"]

--- a/examples/rails_hello/config/secrets.yml
+++ b/examples/rails_hello/config/secrets.yml
@@ -17,7 +17,7 @@ pods:
     web:
       SOME_PASSWORD: "secret"
 
-# You can override secrets by environment.
+# You can override secrets for each target.
 targets:
   production:
     common:

--- a/examples/rails_hello/pods/db.metadata.yml
+++ b/examples/rails_hello/pods/db.metadata.yml
@@ -9,3 +9,10 @@ pod_type: "placeholder"
 # `"test"` to this list.
 enable_in_targets:
 - "development"
+
+# A list of commands to run automatically when `cage up --init` is called
+# on this pod.  These behave as though passed to `cage run`, so the first
+# argument must be the name of a pod or a service.
+run_on_init:
+- ["rake", "db:create"]
+- ["rake", "db:migrate"]

--- a/examples/rails_hello/pods/db.metadata.yml
+++ b/examples/rails_hello/pods/db.metadata.yml
@@ -14,5 +14,10 @@ enable_in_targets:
 # on this pod.  These behave as though passed to `cage run`, so the first
 # argument must be the name of a pod or a service.
 run_on_init:
+# Cage makes sure that PostgreSQL is listening on the expected port, but
+# even once the port is open, we may need to wait longer while it finishes
+# disk recovery.  We can run do this by running a script in the `db` pod.
+- ["db", "bash", "-c", "while ! pg_isready -q -h db; do sleep 0.25; done"]
+# Use the `rake` pod to create our database.
 - ["rake", "db:create"]
 - ["rake", "db:migrate"]

--- a/examples/vault_integration/pods/db.metadata.yml
+++ b/examples/vault_integration/pods/db.metadata.yml
@@ -9,3 +9,10 @@ pod_type: "placeholder"
 # `"test"` to this list.
 enable_in_targets:
 - "development"
+
+# A list of commands to run automatically when `cage up --init` is called
+# on this pod.  These behave as though passed to `cage run`, so the first
+# argument must be the name of a pod or a service.
+run_on_init:
+- ["rake", "db:create"]
+- ["rake", "db:migrate"]

--- a/examples/vault_integration/pods/db.metadata.yml
+++ b/examples/vault_integration/pods/db.metadata.yml
@@ -14,5 +14,10 @@ enable_in_targets:
 # on this pod.  These behave as though passed to `cage run`, so the first
 # argument must be the name of a pod or a service.
 run_on_init:
+# Cage makes sure that PostgreSQL is listening on the expected port, but
+# even once the port is open, we may need to wait longer while it finishes
+# disk recovery.  We can run do this by running a script in the `db` pod.
+- ["db", "bash", "-c", "while ! pg_isready -q -h db; do sleep 0.25; done"]
+# Use the `rake` pod to create our database.
 - ["rake", "db:create"]
 - ["rake", "db:migrate"]

--- a/examples/vault_integration/pods/db.yml
+++ b/examples/vault_integration/pods/db.yml
@@ -3,14 +3,19 @@
 # Amazon RDS or Heroku Postgres.
 
 version: "2"
-services:
 
+services:
   db:
     image: "postgres"
     # We can use a relative volume here because this pod is only used
     # in development mode.
     volumes:
-    - "../data/db:/var/lib/postgresql/data"
+    - "db:/var/lib/postgresql/data"
     labels:
       # Choose a more useful shell.
       io.fdy.cage.shell: "bash"
+
+volumes:
+  # This will create a persistent data volume that you can manage
+  # with the `docker volume` subcommand.
+  db: {}

--- a/src/args/opts.rs
+++ b/src/args/opts.rs
@@ -23,7 +23,7 @@ impl ToArgs for Empty {
 #[allow(missing_copy_implementations)]
 pub struct Up {
     /// Should we initialize each pod after we start it up?
-    init: bool,
+    pub init: bool,
 
     /// PRIVATE: This field is a stand-in for future options.
     /// See http://stackoverflow.com/q/39277157/12089

--- a/src/args/opts.rs
+++ b/src/args/opts.rs
@@ -22,10 +22,23 @@ impl ToArgs for Empty {
 #[derive(Debug, Default, Clone)]
 #[allow(missing_copy_implementations)]
 pub struct Up {
+    /// Should we initialize each pod after we start it up?
+    init: bool,
+
     /// PRIVATE: This field is a stand-in for future options.
     /// See http://stackoverflow.com/q/39277157/12089
     #[doc(hidden)]
     _nonexhaustive: (),
+}
+
+impl Up {
+    /// Create new `Up` options.
+    pub fn new(init: bool) -> Up {
+        Up {
+            init: init,
+            _nonexhaustive: (),
+        }
+    }
 }
 
 impl ToArgs for Up {

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -76,6 +76,9 @@ subcommands:
   - up:
       about: "Run project"
       args:
+        - init:
+            long: "--init"
+            help: "Run any pod initialization commands (for first startup)"
         - POD_OR_SERVICE: *pod_or_service
   - stop:
       about: "Stop all containers associated with project"

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -27,10 +27,7 @@ after_help: |
   From inside a project directory:
 
       cage pull                      # Download images for the a project
-      cage up db                     # Start just the database pod running
-      cage run rake db:create        # Run task in 'pods/rake.yml' with args
-      cage run rake db:migrate       # ...and with different args
-      cage up                        # Start the whole application running
+      cage up --init                 # Start the app, initializing the database
       cage status                    # Get an overview of the project
 
   Access your application at http://localhost:3000/.  To download and edit

--- a/src/cmd/compose.rs
+++ b/src/cmd/compose.rs
@@ -79,10 +79,10 @@ impl CommandCompose for Project {
         let target = self.current_target();
         if pod.enabled_in(target) {
             try!(runner.build("docker-compose")
-                 .args(&try!(pod.compose_args(self, target)))
-                 .arg(command)
-                 .args(&opts.to_args())
-                 .exec());
+                .args(&try!(pod.compose_args(self, target)))
+                .arg(command)
+                .args(&opts.to_args())
+                .exec());
         }
         Ok(())
     }
@@ -99,11 +99,11 @@ impl CommandCompose for Project {
         let target = self.current_target();
         if pod.enabled_in(target) {
             try!(runner.build("docker-compose")
-                 .args(&try!(pod.compose_args(self, target)))
-                 .arg(command)
-                 .args(&opts.to_args())
-                 .arg(service_name)
-                 .exec());
+                .args(&try!(pod.compose_args(self, target)))
+                .arg(command)
+                .args(&opts.to_args())
+                .arg(service_name)
+                .exec());
         }
         Ok(())
     }

--- a/src/cmd/logs.rs
+++ b/src/cmd/logs.rs
@@ -6,7 +6,6 @@ use command_runner::CommandRunner;
 #[cfg(test)]
 use command_runner::TestCommandRunner;
 use errors::*;
-use pod::{Pod, PodType};
 use project::Project;
 
 /// We implement `logs` with a trait so we put it in its own module.
@@ -30,8 +29,7 @@ impl CommandLogs for Project {
     {
         match *act_on {
             args::ActOn::Named(ref names) if names.len() == 1 => {
-                let pred = |p: &Pod| p.pod_type() != PodType::Task;
-                self.compose(runner, "logs", act_on, pred, opts)
+                self.compose(runner, "logs", act_on, opts)
             }
             _ => Err("You may only specify a single service or pod".into()),
         }

--- a/src/cmd/pull.rs
+++ b/src/cmd/pull.rs
@@ -26,7 +26,7 @@ impl CommandPull for Project {
 
         // Pass everything else off to `compose`, as usual.
         let opts = args::opts::Empty;
-        self.compose(runner, "pull", act_on, |_| true, &opts)
+        self.compose(runner, "pull", act_on, &opts)
     }
 }
 

--- a/src/cmd/up.rs
+++ b/src/cmd/up.rs
@@ -66,7 +66,8 @@ impl CommandUp for Project {
         for cmd in pod.run_on_init() {
             if cmd.len() < 1 {
                 return Err("all `run_on_init` items for '{}' \
-                            must have at least one value".into());
+                            must have at least one value"
+                    .into());
             }
             let pod_name = &cmd[0];
             let cmd = if cmd.len() >= 2 {

--- a/src/cmd/up.rs
+++ b/src/cmd/up.rs
@@ -1,12 +1,12 @@
 //! The `up` command.
 
 use args;
-use cmd::CommandCompose;
+use cmd::{CommandCompose, CommandRun};
 use command_runner::CommandRunner;
 #[cfg(test)]
 use command_runner::TestCommandRunner;
 use errors::*;
-use pod::PodType;
+use pod::{Pod, PodType};
 use project::{PodOrService, Project};
 
 /// We implement `up` with a trait so we put it in its own module.
@@ -17,6 +17,10 @@ pub trait CommandUp {
               act_on: &args::ActOn,
               opts: &args::opts::Up)
               -> Result<()>
+        where CR: CommandRunner;
+
+    /// Run the initialization functions for the specified pod.
+    fn init_pod<CR>(&self, runner: &CR, pod: &Pod) -> Result<()>
         where CR: CommandRunner;
 }
 
@@ -29,6 +33,7 @@ impl CommandUp for Project {
         where CR: CommandRunner
     {
         let pods_or_services = act_on.pods_or_services(self)
+            // TODO LOW: Refactor this into a `filter_result` helper?
             .filter(|v| {
                 match *v {
                     Ok(ref p_s) => p_s.pod_type() != PodType::Task,
@@ -39,6 +44,9 @@ impl CommandUp for Project {
             match try!(pod_or_service) {
                 PodOrService::Pod(pod) => {
                     try!(self.compose_pod(runner, "up", pod, opts));
+                    if opts.init {
+                        try!(self.init_pod(runner, pod));
+                    }
                 }
                 PodOrService::Service(pod, service_name) => {
                     try!(self.compose_service(runner,
@@ -48,6 +56,26 @@ impl CommandUp for Project {
                                               opts));
                 }
             }
+        }
+        Ok(())
+    }
+
+    fn init_pod<CR>(&self, runner: &CR, pod: &Pod) -> Result<()>
+        where CR: CommandRunner
+    {
+        for cmd in pod.run_on_init() {
+            if cmd.len() < 1 {
+                return Err("all `run_on_init` items for '{}' \
+                            must have at least one value".into());
+            }
+            let pod_name = &cmd[0];
+            let cmd = if cmd.len() >= 2 {
+                Some(args::Command::new(&cmd[1]).with_args(&cmd[2..]))
+            } else {
+                None
+            };
+            let opts = args::opts::Run::default();
+            try!(self.run(runner, pod_name, cmd.as_ref(), &opts));
         }
         Ok(())
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,6 +9,7 @@
 #![cfg_attr(feature="clippy", allow(redundant_closure))]
 
 use compose_yml::v2 as dc;
+use docker::errors as docker;
 use glob;
 use semver;
 use std::ffi::OsString;
@@ -24,6 +25,7 @@ error_chain! {
     // conversions are implicit.
     links {
         dc::Error, dc::ErrorKind, Compose;
+        docker::Error, docker::ErrorKind, Docker;
     }
 
     // TODO HIGH: Most of these will go away as we convert them to more
@@ -41,6 +43,18 @@ error_chain! {
         CommandFailed(command: Vec<OsString>) {
             description("error running external command")
             display("error running '{}'", command_to_string(&command))
+        }
+
+        /// We could not look up our project's `RuntimeState` using Docker.
+        CouldNotGetRuntimeState {
+            description("error getting the project's state from Docker")
+            display("error getting the project's state from Docker")
+        }
+
+        /// We failed to parse a string.
+        CouldNotParse(parsing_as: &'static str, input: String) {
+            description("failed to parse string")
+            display("failed to parse '{}' as {}", &input, parsing_as)
         }
 
         /// An error occurred reading a directory.
@@ -130,6 +144,15 @@ error_chain! {
             description("an error occurred talking to a Vault server")
             display("an error occurred talking to the Vault server at {}", &url)
         }
+    }
+}
+
+impl ErrorKind {
+    /// Build an `ErrorKind::CouldNotParse` value.
+    pub fn parse<S>(parsing_as: &'static str, input: S) -> ErrorKind
+        where S: Into<String>
+    {
+        ErrorKind::CouldNotParse(parsing_as, input.into())
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(feature="clippy", allow(redundant_closure))]
 
 use compose_yml::v2 as dc;
-use docker::errors as docker;
+use boondock::errors as boondock;
 use glob;
 use semver;
 use std::ffi::OsString;
@@ -25,7 +25,7 @@ error_chain! {
     // conversions are implicit.
     links {
         dc::Error, dc::ErrorKind, Compose;
-        docker::Error, docker::ErrorKind, Docker;
+        boondock::Error, boondock::ErrorKind, Docker;
     }
 
     // TODO HIGH: Most of these will go away as we convert them to more

--- a/src/ext/service.rs
+++ b/src/ext/service.rs
@@ -34,7 +34,8 @@ pub trait ServiceExt {
     /// `Service` object, so you can use it to decide how you want to
     /// update other fields of this object without running afoul of the
     /// borrow checker.
-    fn sources<'a, 'b>(&'a self, sources: &'b sources::Sources)
+    fn sources<'a, 'b>(&'a self,
+                       sources: &'b sources::Sources)
                        -> Result<Sources<'b>>;
 }
 
@@ -74,12 +75,12 @@ impl ServiceExt for dc::Service {
         }
     }
 
-    fn sources<'a, 'b>(&'a self, sources: &'b sources::Sources)
+    fn sources<'a, 'b>(&'a self,
+                       sources: &'b sources::Sources)
                        -> Result<Sources<'b>> {
         // Get our `context`, if any.
         let source_mount_dir = try!(self.source_mount_dir());
-        let context = try!(self.context())
-            .map(|ctx| (source_mount_dir, ctx.clone()));
+        let context = try!(self.context()).map(|ctx| (source_mount_dir, ctx.clone()));
 
         // Get our library keys and mount points.
         let mut libs = vec![];

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -89,7 +89,10 @@ fn runs_requested_hook_scripts() {
 
     proj.hooks().invoke(&runner, "pull", &BTreeMap::default()).unwrap();
     assert_ran!(runner, {
-        [proj.root_dir().join("config").join("hooks").join("pull.d")
+        [proj.root_dir()
+             .join("config")
+             .join("hooks")
+             .join("pull.d")
              .join("hello.hook")]
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 
 extern crate colored;
 extern crate compose_yml;
-extern crate docker;
+extern crate boondock;
 #[cfg(test)]
 extern crate env_logger;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@
 
 extern crate colored;
 extern crate compose_yml;
+extern crate docker;
 #[cfg(test)]
 extern crate env_logger;
 #[macro_use]
@@ -91,6 +92,7 @@ extern crate phf;
 #[cfg(test)]
 extern crate rand;
 extern crate rayon;
+extern crate regex;
 extern crate retry;
 extern crate rustc_serialize;
 extern crate semver;
@@ -106,6 +108,7 @@ pub use default_tags::DefaultTags;
 pub use errors::*;
 pub use project::{PodOrService, Project, ProjectConfig, Pods, Targets};
 pub use pod::{Pod, PodType, TargetFiles, AllFiles};
+pub use runtime_state::RuntimeState;
 pub use sources::{Sources, Source};
 pub use sources::Iter as SourceIter;
 pub use target::Target;
@@ -125,6 +128,7 @@ pub mod hook;
 pub mod plugins;
 mod pod;
 mod project;
+mod runtime_state;
 mod serde_helpers;
 mod service_locations;
 mod sources;

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,7 +196,7 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
         "build" => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE");
             let opts = cage::args::opts::Empty;
-            try!(proj.compose(&runner, "build", &acts_on, |_| true, &opts));
+            try!(proj.compose(&runner, "build", &acts_on, &opts));
         }
         "up" => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE");
@@ -206,12 +206,12 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
         "stop" => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE");
             let opts = cage::args::opts::Empty;
-            try!(proj.compose(&runner, "stop", &acts_on, |_| true, &opts));
+            try!(proj.compose(&runner, "stop", &acts_on, &opts));
         }
         "rm" => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE");
             let opts = cage::args::opts::Empty;
-            try!(proj.compose(&runner, "rm", &acts_on, |_| true, &opts));
+            try!(proj.compose(&runner, "rm", &acts_on, &opts));
         }
         "run" => {
             let opts = sc_matches.to_run_options();

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,7 +200,7 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
         }
         "up" => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE");
-            let opts = cage::args::opts::Up::default();
+            let opts = cage::args::opts::Up::new(sc_matches.is_present("init"));
             try!(proj.up(&runner, &acts_on, &opts));
         }
         "stop" => {

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -285,6 +285,11 @@ impl Pod {
                 "-f".into(),
                 proj.output_pods_dir().join(self.rel_path()).into()])
     }
+
+    /// The commands we should run to initialize this pod.
+    pub fn run_on_init(&self) -> &[Vec<String>] {
+        &self.config.run_on_init
+    }
 }
 
 /// An iterator over this pods targets and their associated files.

--- a/src/pod_config.in.rs
+++ b/src/pod_config.in.rs
@@ -41,4 +41,9 @@ struct Config {
 
     /// What kind of pod is this?
     pod_type: Option<PodType>,
+
+    /// A list of commands to invoke with `cage run` when this pod is
+    /// initialized.
+    #[serde(default, skip_serializing_if="Vec::is_empty")]
+    run_on_init: Vec<Vec<String>>,
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -47,6 +47,17 @@ pub enum PodOrService<'a> {
     Service(&'a Pod, &'a str),
 }
 
+impl<'a> PodOrService<'a> {
+    /// Get the `pod_type` for either our `Pod` or the pod containing our
+    /// service.
+    pub fn pod_type(&self) -> PodType {
+        match *self {
+            PodOrService::Pod(pod) |
+            PodOrService::Service(pod, _) => pod.pod_type(),
+        }
+    }
+}
+
 /// A `cage` project, which is represented as a directory containing a
 /// `pods` subdirectory.
 #[derive(Debug)]

--- a/src/project.rs
+++ b/src/project.rs
@@ -2,6 +2,7 @@
 
 #[cfg(test)]
 use compose_yml::v2 as dc;
+use regex::Regex;
 use semver;
 use serde_yaml;
 use std::collections::BTreeMap;
@@ -251,6 +252,15 @@ impl Project {
     pub fn set_name(&mut self, name: &str) -> &mut Project {
         self.name = name.to_owned();
         self
+    }
+
+    /// The normalized name for this project used by `docker-compose`
+    /// internally.
+    pub fn normalized_name(&self) -> String {
+        lazy_static! {
+            static ref NON_ALNUM: Regex = Regex::new(r#"[^a-z0-9]"#).unwrap();
+        }
+        NON_ALNUM.replace_all(&self.name, "")
     }
 
     /// The root directory of this project.

--- a/src/runtime_state.rs
+++ b/src/runtime_state.rs
@@ -1,0 +1,174 @@
+//! Support for fetching runtime state directly from the Docker daemon.
+
+use docker;
+use regex::Regex;
+use std::collections::BTreeMap;
+use std::net;
+
+use errors::*;
+use project::Project;
+
+/// Everything we know about the running application, based on querying Docker.
+#[derive(Debug)]
+pub struct RuntimeState {
+    /// Map service names to information about associated containers.
+    services: BTreeMap<String, Vec<ContainerInfo>>,
+}
+
+impl RuntimeState {
+    /// Look up the runtime state for the specified project (and its
+    /// current target).
+    pub fn for_project(project: &Project) -> Result<RuntimeState> {
+        // Standardize our error messages since this is going to fail a lot
+        // until we debug all the Docker wire formats and undocumented
+        // special cases.
+        Self::for_project_inner(project)
+            .chain_err(|| ErrorKind::CouldNotGetRuntimeState)
+    }
+
+    /// The actual implementation of `for_project`.
+    fn for_project_inner(project: &Project) -> Result<RuntimeState> {
+        let name = project.normalized_name();
+        let target = project.current_target().name().to_owned();
+        let docker = try!(docker::Docker::connect_with_defaults());
+
+        let mut services = BTreeMap::new();
+        let containers = try!(docker.get_containers(true));
+        for container in &containers {
+            let info = try!(docker.get_container_info(&container));
+            let labels = &info.Config.Labels;
+            if labels.get("com.docker.compose.project") == Some(&name)
+                && labels.get("io.fdy.cage.target") == Some(&target)
+            {
+                if let Some(service) = labels.get("com.docker.compose.service") {
+                    let our_info = try!(ContainerInfo::new(&info));
+                    services.entry(service.to_owned())
+                        .or_insert_with(Vec::new)
+                        .push(our_info);
+                }
+            }
+        }
+        Ok(RuntimeState { services: services })
+    }
+
+    /// Get the containers associated with a service.  This will return the
+    /// empty list if it can't find any containers related to the specified
+    /// `service_name`.
+    pub fn service_containers(&self, service_name: &str) -> &[ContainerInfo] {
+        self.services.get(service_name)
+            .map_or_else(|| &[] as &[ContainerInfo],
+                         |containers| &containers[..])
+    }
+}
+
+/// Information about a specific container associated with a service.
+#[derive(Debug, Clone)]
+pub struct ContainerInfo {
+    /// The current state of this container.
+    state: ContainerState,
+
+    /// An IP address at which we can access this container.
+    ip_addr: Option<net::IpAddr>,
+
+    /// The TCP ports this container is listening on (not the corresponding
+    /// host ports!).
+    container_tcp_ports: Vec<u16>,
+}
+
+impl ContainerInfo {
+    /// Construct our summary from the raw data returned by Docker.
+    fn new(info: &docker::container::ContainerInfo) -> Result<ContainerInfo> {
+        // Get an IP address for this running container.
+        let raw_ip_addr = &info.NetworkSettings.IPAddress[..];
+        let ip_addr = if raw_ip_addr != "" {
+            Some(try!(raw_ip_addr.parse()
+                    .chain_err(|| ErrorKind::parse("IP address", raw_ip_addr))))
+        } else {
+            None
+        };
+
+        // Get the listening network ports.
+        let mut ports = vec![];
+        for port_str in info.NetworkSettings.Ports.keys() {
+            lazy_static! {
+                static ref TCP_PORT: Regex = Regex::new(r#"^(\d+)/tcp$"#).unwrap();
+            }
+            if let Some(caps) = TCP_PORT.captures(port_str) {
+                let port = try!(caps.at(1).unwrap().parse()
+                    .chain_err(|| ErrorKind::parse("TCP port", port_str.clone())));
+                ports.push(port);
+            }
+        }
+
+        Ok(ContainerInfo {
+            state: ContainerState::new(&info.State),
+            ip_addr: ip_addr,
+            container_tcp_ports: ports,
+        })
+    }
+
+    /// The current state of this container.
+    pub fn state(&self) -> ContainerState {
+        self.state
+    }
+
+    /// An IP address at which we can access this container.
+    pub fn ip_addr(&self) -> Option<net::IpAddr> {
+        self.ip_addr
+    }
+
+    /// The TCP ports this container is listening on (not the corresponding
+    /// host ports!).
+    pub fn container_tcp_ports(&self) -> &[u16] {
+        &self.container_tcp_ports
+    }
+
+    /// The socket addresses this container is listening on.
+    pub fn socket_addrs(&self) -> Vec<net::SocketAddr> {
+        self.ip_addr()
+            .map(|addr| {
+                self.container_tcp_ports.iter()
+                    .map(|port| net::SocketAddr::new(addr, *port))
+                    .collect()
+            })
+            .unwrap_or_else(Vec::new)
+    }
+
+    /// Is this container listening to its ports?
+    pub fn is_listening_to_ports(&self) -> bool {
+        for addr in self.socket_addrs() {
+            if net::TcpListener::bind(addr).is_err() {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// Is a Docker container running? Stopped?
+#[derive(Debug, Clone, Copy)]
+pub enum ContainerState {
+    /// The container is current running.
+    Running,
+    /// The container is stopped with exit code 0.
+    Done,
+    /// The container is stopped with a non-zero exit code.
+    Error(i64),
+    /// The container is in some other state.
+    Other,
+}
+
+impl ContainerState {
+    /// Create a new `ContainerState` from Docker data.
+    fn new(state: &docker::container::State) -> ContainerState {
+        if state.Running {
+            ContainerState::Running
+        } else if state.Dead && state.ExitCode == 0 {
+            ContainerState::Done
+        } else if state.Dead {
+            ContainerState::Error(state.ExitCode)
+        } else {
+            ContainerState::Other
+        }
+    }
+}

--- a/src/runtime_state.rs
+++ b/src/runtime_state.rs
@@ -1,6 +1,6 @@
 //! Support for fetching runtime state directly from the Docker daemon.
 
-use docker;
+use boondock;
 use regex::Regex;
 use std::collections::BTreeMap;
 use std::net;
@@ -30,7 +30,7 @@ impl RuntimeState {
     fn for_project_inner(project: &Project) -> Result<RuntimeState> {
         let name = project.normalized_name();
         let target = project.current_target().name().to_owned();
-        let docker = try!(docker::Docker::connect_with_defaults());
+        let docker = try!(boondock::Docker::connect_with_defaults());
 
         let mut services = BTreeMap::new();
         let containers = try!(docker.get_containers(true));
@@ -76,7 +76,7 @@ pub struct ContainerInfo {
 
 impl ContainerInfo {
     /// Construct our summary from the raw data returned by Docker.
-    fn new(info: &docker::container::ContainerInfo) -> Result<ContainerInfo> {
+    fn new(info: &boondock::container::ContainerInfo) -> Result<ContainerInfo> {
         // Get an IP address for this running container.
         let raw_ip_addr = &info.NetworkSettings.IPAddress[..];
         let ip_addr = if raw_ip_addr != "" {
@@ -164,7 +164,7 @@ pub enum ContainerState {
 
 impl ContainerState {
     /// Create a new `ContainerState` from Docker data.
-    fn new(state: &docker::container::State) -> ContainerState {
+    fn new(state: &boondock::container::State) -> ContainerState {
         if state.Running {
             ContainerState::Running
         } else if state.Dead && state.ExitCode == 0 {

--- a/src/runtime_state.rs
+++ b/src/runtime_state.rs
@@ -37,9 +37,8 @@ impl RuntimeState {
         for container in &containers {
             let info = try!(docker.get_container_info(&container));
             let labels = &info.Config.Labels;
-            if labels.get("com.docker.compose.project") == Some(&name)
-                && labels.get("io.fdy.cage.target") == Some(&target)
-            {
+            if labels.get("com.docker.compose.project") == Some(&name) &&
+               labels.get("io.fdy.cage.target") == Some(&target) {
                 if let Some(service) = labels.get("com.docker.compose.service") {
                     let our_info = try!(ContainerInfo::new(&info));
                     services.entry(service.to_owned())
@@ -55,9 +54,9 @@ impl RuntimeState {
     /// empty list if it can't find any containers related to the specified
     /// `service_name`.
     pub fn service_containers(&self, service_name: &str) -> &[ContainerInfo] {
-        self.services.get(service_name)
-            .map_or_else(|| &[] as &[ContainerInfo],
-                         |containers| &containers[..])
+        self.services
+            .get(service_name)
+            .map_or_else(|| &[] as &[ContainerInfo], |containers| &containers[..])
     }
 }
 
@@ -127,7 +126,8 @@ impl ContainerInfo {
     pub fn socket_addrs(&self) -> Vec<net::SocketAddr> {
         self.ip_addr()
             .map(|addr| {
-                self.container_tcp_ports.iter()
+                self.container_tcp_ports
+                    .iter()
                     .map(|port| net::SocketAddr::new(addr, *port))
                     .collect()
             })

--- a/src/runtime_state.rs
+++ b/src/runtime_state.rs
@@ -81,7 +81,7 @@ impl ContainerInfo {
         let raw_ip_addr = &info.NetworkSettings.IPAddress[..];
         let ip_addr = if raw_ip_addr != "" {
             Some(try!(raw_ip_addr.parse()
-                    .chain_err(|| ErrorKind::parse("IP address", raw_ip_addr))))
+                .chain_err(|| ErrorKind::parse("IP address", raw_ip_addr))))
         } else {
             None
         };
@@ -93,7 +93,9 @@ impl ContainerInfo {
                 static ref TCP_PORT: Regex = Regex::new(r#"^(\d+)/tcp$"#).unwrap();
             }
             if let Some(caps) = TCP_PORT.captures(port_str) {
-                let port = try!(caps.at(1).unwrap().parse()
+                let port = try!(caps.at(1)
+                    .unwrap()
+                    .parse()
                     .chain_err(|| ErrorKind::parse("TCP port", port_str.clone())));
                 ports.push(port);
             }
@@ -138,8 +140,10 @@ impl ContainerInfo {
     pub fn is_listening_to_ports(&self) -> bool {
         for addr in self.socket_addrs() {
             if net::TcpListener::bind(addr).is_err() {
+                trace!("scanned {}: CLOSED", addr);
                 return false;
             }
+            trace!("scanned {}: OPEN", addr);
         }
         true
     }


### PR DESCRIPTION
In order to support initializating containers easily, we add an `up --init` command, which can invoke one or more `cage run` tasks to create database, apply migrations, etc. In order to make this reliable, we have a little magic:

1. We query the Docker daemon at runtime to get a list of exported ports for a container and its IP address.
2. We "port scan" the container to repeatedly until all the ports open up.

We also use this new Docker support to enhance `cage status` a bit.