### PR TITLE
Strip the `build` field from the generated compose files

### DIFF
--- a/src/cmd/compose.rs
+++ b/src/cmd/compose.rs
@@ -7,6 +7,8 @@ use command_runner::TestCommandRunner;
 use errors::*;
 use pod::Pod;
 use project::{PodOrService, Project};
+#[cfg(test)]
+use subcommand::Subcommand;
 
 /// Pass simple commands directly through to `docker-compose`.
 pub trait CommandCompose {
@@ -109,7 +111,7 @@ fn runs_docker_compose_on_all_pods() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("stop").unwrap();
+    proj.output(Subcommand::Stop).unwrap();
 
     let opts = args::opts::Empty;
     proj.compose(&runner, "stop", &args::ActOn::All, &opts).unwrap();
@@ -143,7 +145,7 @@ fn runs_docker_compose_on_named_pods_and_services() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("stop").unwrap();
+    proj.output(Subcommand::Stop).unwrap();
 
     let act_on = args::ActOn::Named(vec!("db".to_owned(), "web".to_owned()));
     let opts = args::opts::Empty;

--- a/src/cmd/compose.rs
+++ b/src/cmd/compose.rs
@@ -109,7 +109,7 @@ fn runs_docker_compose_on_all_pods() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("stop").unwrap();
 
     let opts = args::opts::Empty;
     proj.compose(&runner, "stop", &args::ActOn::All, &opts).unwrap();
@@ -143,7 +143,7 @@ fn runs_docker_compose_on_named_pods_and_services() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("stop").unwrap();
 
     let act_on = args::ActOn::Named(vec!("db".to_owned(), "web".to_owned()));
     let opts = args::opts::Empty;

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -7,6 +7,8 @@ use command_runner::TestCommandRunner;
 use errors::*;
 use ext::service::ServiceExt;
 use project::Project;
+#[cfg(test)]
+use subcommand::Subcommand;
 use util::err;
 
 /// We implement `exec` with a trait so we can put it in its own
@@ -80,7 +82,7 @@ fn invokes_docker_exec() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("exec").unwrap();
+    proj.output(Subcommand::Exec).unwrap();
 
     let command = args::Command::new("true");
     let mut opts = args::opts::Exec::default();
@@ -108,7 +110,7 @@ fn runs_shells() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("exec").unwrap();
+    proj.output(Subcommand::Exec).unwrap();
 
     proj.shell(&runner, "web", &Default::default()).unwrap();
 

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -80,7 +80,7 @@ fn invokes_docker_exec() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("exec").unwrap();
 
     let command = args::Command::new("true");
     let mut opts = args::opts::Exec::default();
@@ -108,7 +108,7 @@ fn runs_shells() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("exec").unwrap();
 
     proj.shell(&runner, "web", &Default::default()).unwrap();
 

--- a/src/cmd/logs.rs
+++ b/src/cmd/logs.rs
@@ -7,6 +7,8 @@ use command_runner::CommandRunner;
 use command_runner::TestCommandRunner;
 use errors::*;
 use project::Project;
+#[cfg(test)]
+use subcommand::Subcommand;
 
 /// We implement `logs` with a trait so we put it in its own module.
 pub trait CommandLogs {
@@ -42,7 +44,7 @@ fn runs_docker_compose_logs() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("logs").unwrap();
+    proj.output(Subcommand::Logs).unwrap();
 
     let opts = args::opts::Logs::default();
     proj.logs(&runner,
@@ -67,7 +69,7 @@ fn errors_when_act_on_specifies_multiple_containers() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("logs").unwrap();
+    proj.output(Subcommand::Logs).unwrap();
 
     let opts = args::opts::Logs::default();
     assert!(proj.logs(&runner, &args::ActOn::All, &opts).is_err());

--- a/src/cmd/logs.rs
+++ b/src/cmd/logs.rs
@@ -42,7 +42,7 @@ fn runs_docker_compose_logs() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("logs").unwrap();
 
     let opts = args::opts::Logs::default();
     proj.logs(&runner,
@@ -67,7 +67,7 @@ fn errors_when_act_on_specifies_multiple_containers() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("logs").unwrap();
 
     let opts = args::opts::Logs::default();
     assert!(proj.logs(&runner, &args::ActOn::All, &opts).is_err());

--- a/src/cmd/pull.rs
+++ b/src/cmd/pull.rs
@@ -36,7 +36,7 @@ fn runs_docker_compose_pull_on_all_pods() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("pull").unwrap();
 
     proj.pull(&runner, &args::ActOn::All).unwrap();
     assert_ran!(runner, {

--- a/src/cmd/pull.rs
+++ b/src/cmd/pull.rs
@@ -9,6 +9,8 @@ use command_runner::CommandRunner;
 use command_runner::TestCommandRunner;
 use errors::*;
 use project::Project;
+#[cfg(test)]
+use subcommand::Subcommand;
 
 /// We implement `pull` with a trait so we put it in its own module.
 pub trait CommandPull {
@@ -36,7 +38,7 @@ fn runs_docker_compose_pull_on_all_pods() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("pull").unwrap();
+    proj.output(Subcommand::Pull).unwrap();
 
     proj.pull(&runner, &args::ActOn::All).unwrap();
     assert_ran!(runner, {

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -7,6 +7,8 @@ use command_runner::TestCommandRunner;
 use errors::*;
 use ext::service::ServiceExt;
 use project::Project;
+#[cfg(test)]
+use subcommand::Subcommand;
 
 /// We implement `run` with a trait so we put it in its own module.
 pub trait CommandRun {
@@ -99,7 +101,7 @@ fn fails_on_a_multi_service_pod() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("run").unwrap();
+    proj.output(Subcommand::Run).unwrap();
     let opts = Default::default();
     assert!(proj.run(&runner, "frontend", None, &opts).is_err());
 }
@@ -110,7 +112,7 @@ fn runs_a_single_service_pod() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("run").unwrap();
+    proj.output(Subcommand::Run).unwrap();
     let cmd = args::Command::new("db:migrate");
     let mut opts = args::opts::Run::default();
     opts.allocate_tty = false;
@@ -136,7 +138,7 @@ fn runs_tests() {
     let mut proj = Project::from_example("hello").unwrap();
     proj.set_current_target_name("test").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("test").unwrap();
+    proj.output(Subcommand::Test).unwrap();
 
     proj.test(&runner, "frontend/proxy", None).unwrap();
 
@@ -164,7 +166,7 @@ fn runs_tests_with_custom_command() {
     let mut proj = Project::from_example("hello").unwrap();
     proj.set_current_target_name("test").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("test").unwrap();
+    proj.output(Subcommand::Test).unwrap();
 
     let cmd = args::Command::new("rspec").with_args(&["-t", "foo"]);
     proj.test(&runner, "proxy", Some(&cmd)).unwrap();

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -99,7 +99,7 @@ fn fails_on_a_multi_service_pod() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("run").unwrap();
     let opts = Default::default();
     assert!(proj.run(&runner, "frontend", None, &opts).is_err());
 }
@@ -110,7 +110,7 @@ fn runs_a_single_service_pod() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("run").unwrap();
     let cmd = args::Command::new("db:migrate");
     let mut opts = args::opts::Run::default();
     opts.allocate_tty = false;
@@ -136,7 +136,7 @@ fn runs_tests() {
     let mut proj = Project::from_example("hello").unwrap();
     proj.set_current_target_name("test").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("test").unwrap();
 
     proj.test(&runner, "frontend/proxy", None).unwrap();
 
@@ -164,7 +164,7 @@ fn runs_tests_with_custom_command() {
     let mut proj = Project::from_example("hello").unwrap();
     proj.set_current_target_name("test").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("test").unwrap();
 
     let cmd = args::Command::new("rspec").with_args(&["-t", "foo"]);
     proj.test(&runner, "proxy", Some(&cmd)).unwrap();

--- a/src/cmd/run_script.rs
+++ b/src/cmd/run_script.rs
@@ -6,6 +6,8 @@ use command_runner::CommandRunner;
 use command_runner::TestCommandRunner;
 use errors::*;
 use project::{Project, PodOrService};
+#[cfg(test)]
+use subcommand::Subcommand;
 
 /// Included into project in order to run named scripts on one ore more services
 pub trait CommandRunScript {
@@ -62,7 +64,7 @@ fn runs_scripts_on_all_services() {
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
     let opts = args::opts::Run::default();
-    proj.output().unwrap();
+    proj.output(Subcommand::RunScript).unwrap();
 
     proj.run_script(&runner, &args::ActOn::All, "routes", &opts).unwrap();
     assert_ran!(runner, {

--- a/src/cmd/up.rs
+++ b/src/cmd/up.rs
@@ -124,7 +124,7 @@ fn runs_docker_compose_up_honors_enable_in_targets() {
     let mut proj = Project::from_example("rails_hello").unwrap();
     proj.set_current_target_name("production").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("up").unwrap();
 
     let opts = args::opts::Up::default();
     proj.up(&runner, &args::ActOn::All, &opts).unwrap();

--- a/src/cmd/up.rs
+++ b/src/cmd/up.rs
@@ -11,6 +11,8 @@ use command_runner::TestCommandRunner;
 use errors::*;
 use pod::{Pod, PodType};
 use project::{PodOrService, Project};
+#[cfg(test)]
+use subcommand::Subcommand;
 use runtime_state::RuntimeState;
 
 /// We implement `up` with a trait so we put it in its own module.
@@ -124,7 +126,7 @@ fn runs_docker_compose_up_honors_enable_in_targets() {
     let mut proj = Project::from_example("rails_hello").unwrap();
     proj.set_current_target_name("production").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("up").unwrap();
+    proj.output(Subcommand::Up).unwrap();
 
     let opts = args::opts::Up::default();
     proj.up(&runner, &args::ActOn::All, &opts).unwrap();

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -93,7 +93,7 @@ fn runs_requested_hook_scripts() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("pull").unwrap();
 
     proj.hooks().invoke(&runner, "pull", &BTreeMap::default()).unwrap();
     assert_ran!(runner, {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -10,6 +10,8 @@ use command_runner::TestCommandRunner;
 use errors::*;
 #[cfg(test)]
 use project::Project;
+#[cfg(test)]
+use subcommand::Subcommand;
 use util::ToStrOrErr;
 
 /// Keeps track of hook scripts and invokes them at appropriate times.
@@ -93,7 +95,7 @@ fn runs_requested_hook_scripts() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output("pull").unwrap();
+    proj.output(Subcommand::Pull).unwrap();
 
     proj.hooks().invoke(&runner, "pull", &BTreeMap::default()).unwrap();
     assert_ran!(runner, {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ pub mod hook;
 pub mod plugins;
 mod pod;
 mod project;
+pub mod subcommand;
 mod runtime_state;
 mod serde_helpers;
 mod service_locations;

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,7 +212,7 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Output our project's `*.yml` files for `docker-compose` if we'll
     // need it.
     if matches.should_output_project() {
-        proj.output()?;
+        proj.output(sc_name)?;
     }
 
     // Handle our subcommands that require a `Project`.
@@ -337,7 +337,7 @@ fn run_source<R>(runner: &R,
 
     // Regenerate our output if it might have changed.
     if re_output {
-        proj.output()?;
+        proj.output(sc_name)?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,19 +319,19 @@ fn run_source<R>(runner: &R,
     // Dispatch our subcommand.
     let mut re_output = true;
     match subcommand {
-        Subcommand::Ls => {
+        Subcommand::SourceLs => {
             re_output = false;
             proj.source_list(runner)?;
         }
-        Subcommand::Clone => {
+        Subcommand::SourceClone => {
             let alias = sc_matches.value_of("ALIAS").unwrap();
             proj.source_clone(runner, alias)?;
         }
-        Subcommand::Mount => {
+        Subcommand::SourceMount => {
             let alias = sc_matches.value_of("ALIAS").unwrap();
             proj.source_set_mounted(runner, alias, true)?;
         }
-        Subcommand::Unmount => {
+        Subcommand::SourceUnmount => {
             let alias = sc_matches.value_of("ALIAS").unwrap();
             proj.source_set_mounted(runner, alias, false)?;
         }
@@ -361,7 +361,7 @@ fn run_generate<R>(_runner: &R,
 
     match subcommand {
         // TODO LOW: Allow running this without a project?
-        Subcommand::Completion => {
+        Subcommand::GenerateCompletion => {
             let shell = match sc_matches.value_of("SHELL").unwrap() {
                 "bash" => clap::Shell::Bash,
                 "fish" => clap::Shell::Fish,

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use yaml_rust::yaml;
 use cage::command_runner::{Command, CommandRunner, OsCommandRunner};
 use cage::cmd::*;
 use cage::Result;
+use cage::subcommand::Subcommand;
 
 /// Load our command-line interface definitions from an external `clap`
 /// YAML file.  We could create these using code, but at the cost of more
@@ -180,16 +181,17 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
     // We know that we always have a subcommand because our `cli.yml`
     // requires this and `clap` is supposed to enforce it.
     let sc_name = matches.subcommand_name().unwrap();
+    let subcommand = sc_name.parse::<Subcommand>().unwrap();
     let sc_matches: &clap::ArgMatches = matches.subcommand_matches(sc_name).unwrap();
 
     // Handle any subcommands that we can handle without a project
     // directory.
-    match sc_name {
-        "sysinfo" => {
+    match subcommand {
+        Subcommand::Sysinfo => {
             all_versions()?;
             return Ok(());
         }
-        "new" => {
+        Subcommand::New => {
             cage::Project::generate_new(&env::current_dir()?,
                                         sc_matches.value_of("NAME").unwrap())?;
             return Ok(());
@@ -212,90 +214,90 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Output our project's `*.yml` files for `docker-compose` if we'll
     // need it.
     if matches.should_output_project() {
-        proj.output(sc_name)?;
+        proj.output(subcommand)?;
     }
 
     // Handle our subcommands that require a `Project`.
     let runner = OsCommandRunner::new();
-    match sc_name {
-        "status" => {
+    match subcommand {
+        Subcommand::Status => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", true);
             proj.status(&runner, &acts_on)?;
         }
-        "pull" => {
+        Subcommand::Pull => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", true);
             proj.pull(&runner, &acts_on)?;
         }
-        "build" => {
+        Subcommand::Build => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", true);
             let opts = cage::args::opts::Empty;
             proj.compose(&runner, "build", &acts_on, &opts)?;
         }
-        "up" => {
+        Subcommand::Up => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", false);
             let opts = cage::args::opts::Up::new(sc_matches.is_present("init"));
             proj.up(&runner, &acts_on, &opts)?;
         }
-        "restart" => {
+        Subcommand::Restart => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", false);
             let opts = cage::args::opts::Empty;
             proj.compose(&runner, "restart", &acts_on, &opts)?;
         }
-        "stop" => {
+        Subcommand::Stop => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", false);
             let opts = cage::args::opts::Empty;
             proj.compose(&runner, "stop", &acts_on, &opts)?;
         }
-        "rm" => {
+        Subcommand::Rm => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", true);
             let opts = sc_matches.to_rm_options();
             proj.compose(&runner, "rm", &acts_on, &opts)?;
         }
-        "run" => {
+        Subcommand::Run => {
             warn_if_pods_are_enabled_but_not_running(&proj)?;
             let opts = sc_matches.to_run_options();
             let cmd = sc_matches.to_exec_command();
             let service = sc_matches.value_of("SERVICE").unwrap();
             proj.run(&runner, service, cmd.as_ref(), &opts)?;
         }
-        "run-script" => {
+        Subcommand::RunScript => {
             warn_if_pods_are_enabled_but_not_running(&proj)?;
             let opts = sc_matches.to_run_options();
             let script_name = sc_matches.value_of("SCRIPT_NAME").unwrap();
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", true);
             proj.run_script(&runner, &acts_on, script_name.as_ref(), &opts)?;
         }
-        "exec" => {
+        Subcommand::Exec => {
             warn_if_pods_are_enabled_but_not_running(&proj)?;
             let service = sc_matches.value_of("SERVICE").unwrap();
             let opts = sc_matches.to_exec_options();
             let cmd = sc_matches.to_exec_command().unwrap();
             proj.exec(&runner, service, &cmd, &opts)?;
         }
-        "shell" => {
+        Subcommand::Shell => {
             warn_if_pods_are_enabled_but_not_running(&proj)?;
             let service = sc_matches.value_of("SERVICE").unwrap();
             let opts = sc_matches.to_exec_options();
             proj.shell(&runner, service, &opts)?;
         }
-        "test" => {
+        Subcommand::Test => {
             warn_if_pods_are_enabled_but_not_running(&proj)?;
             let service = sc_matches.value_of("SERVICE").unwrap();
             let cmd = sc_matches.to_exec_command();
             proj.test(&runner, service, cmd.as_ref())?;
         }
-        "source" => run_source(&runner, &mut proj, sc_matches)?,
-        "generate" => run_generate(&runner, &proj, sc_matches)?,
-        "logs" => {
+        Subcommand::Source => run_source(&runner, &mut proj, sc_matches)?,
+        Subcommand::Generate => run_generate(&runner, &proj, sc_matches)?,
+        Subcommand::Logs => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", true);
             let opts = sc_matches.to_logs_options();
             proj.logs(&runner, &acts_on, &opts)?;
         }
-        "export" => {
+        Subcommand::Export => {
             let dir = sc_matches.value_of("DIR").unwrap();
             proj.export(Path::new(dir))?;
         }
-        unknown => unreachable!("Unexpected subcommand '{}'", unknown),
+        unknown => unreachable!("Unexpected subcommand '{:?}'", unknown),
     }
 
     Ok(())
@@ -311,33 +313,34 @@ fn run_source<R>(runner: &R,
     // We know that we always have a subcommand because our `cli.yml`
     // requires this and `clap` is supposed to enforce it.
     let sc_name = matches.subcommand_name().unwrap();
+    let subcommand = sc_name.parse::<Subcommand>().unwrap();
     let sc_matches: &clap::ArgMatches = matches.subcommand_matches(sc_name).unwrap();
 
     // Dispatch our subcommand.
     let mut re_output = true;
-    match sc_name {
-        "ls" => {
+    match subcommand {
+        Subcommand::Ls => {
             re_output = false;
             proj.source_list(runner)?;
         }
-        "clone" => {
+        Subcommand::Clone => {
             let alias = sc_matches.value_of("ALIAS").unwrap();
             proj.source_clone(runner, alias)?;
         }
-        "mount" => {
+        Subcommand::Mount => {
             let alias = sc_matches.value_of("ALIAS").unwrap();
             proj.source_set_mounted(runner, alias, true)?;
         }
-        "unmount" => {
+        Subcommand::Unmount => {
             let alias = sc_matches.value_of("ALIAS").unwrap();
             proj.source_set_mounted(runner, alias, false)?;
         }
-        unknown => unreachable!("Unexpected subcommand '{}'", unknown),
+        unknown => unreachable!("Unexpected subcommand '{:?}'", unknown),
     }
 
     // Regenerate our output if it might have changed.
     if re_output {
-        proj.output(sc_name)?;
+        proj.output(subcommand)?;
     }
 
     Ok(())
@@ -353,11 +356,12 @@ fn run_generate<R>(_runner: &R,
     // We know that we always have a subcommand because our `cli.yml`
     // requires this and `clap` is supposed to enforce it.
     let sc_name = matches.subcommand_name().unwrap();
+    let subcommand = sc_name.parse::<Subcommand>().unwrap();
     let sc_matches: &clap::ArgMatches = matches.subcommand_matches(sc_name).unwrap();
 
-    match sc_name {
+    match subcommand {
         // TODO LOW: Allow running this without a project?
-        "completion" => {
+        Subcommand::Completion => {
             let shell = match sc_matches.value_of("SHELL").unwrap() {
                 "bash" => clap::Shell::Bash,
                 "fish" => clap::Shell::Fish,
@@ -366,7 +370,7 @@ fn run_generate<R>(_runner: &R,
             let cli_yaml = load_yaml!("cli.yml");
             cli(cli_yaml).gen_completions("cage", shell, proj.root_dir());
         }
-        other => proj.generate(other)?,
+        _ => proj.generate(sc_name)?,
     }
     Ok(())
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -19,16 +19,19 @@ pub struct Context<'a> {
     pub project: &'a Project,
     /// The pod to which we're applying this plugin.
     pub pod: &'a Pod,
+    /// The subcommand to which we're applying this plugin.
+    pub subcommand: String,
     /// PRIVATE. Allow future extensibility without breaking the API.
     _nonexclusive: PhantomData<()>,
 }
 
 impl<'a> Context<'a> {
     /// Create a new plugin context.
-    pub fn new(project: &'a Project, pod: &'a Pod) -> Context<'a> {
+    pub fn new(project: &'a Project, pod: &'a Pod, subcommand: &str) -> Context<'a> {
         Context {
             project: project,
             pod: pod,
+            subcommand: subcommand.to_string(),
             _nonexclusive: PhantomData,
         }
     }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -129,6 +129,7 @@ impl Manager {
         manager.register_transform::<transform::default_tags::Plugin>(proj)?;
         manager.register_transform::<transform::sources::Plugin>(proj)?;
         manager.register_transform::<transform::secrets::Plugin>(proj)?;
+        manager.register_transform::<transform::remove_build::Plugin>(proj)?;
         manager.register_vault_transform(proj)?;
 
         // Run this last, in case it wants to remove any labels used by

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -8,6 +8,7 @@ use std::marker::PhantomData;
 use errors::*;
 use pod::Pod;
 use project::Project;
+use subcommand::Subcommand;
 use template::Template;
 
 pub mod transform;
@@ -20,18 +21,18 @@ pub struct Context<'a> {
     /// The pod to which we're applying this plugin.
     pub pod: &'a Pod,
     /// The subcommand to which we're applying this plugin.
-    pub subcommand: String,
+    pub subcommand: Subcommand,
     /// PRIVATE. Allow future extensibility without breaking the API.
     _nonexclusive: PhantomData<()>,
 }
 
 impl<'a> Context<'a> {
     /// Create a new plugin context.
-    pub fn new(project: &'a Project, pod: &'a Pod, subcommand: &str) -> Context<'a> {
+    pub fn new(project: &'a Project, pod: &'a Pod, subcommand: Subcommand) -> Context<'a> {
         Context {
             project: project,
             pod: pod,
-            subcommand: subcommand.to_string(),
+            subcommand: subcommand,
             _nonexclusive: PhantomData,
         }
     }

--- a/src/plugins/transform/mod.rs
+++ b/src/plugins/transform/mod.rs
@@ -3,6 +3,7 @@
 pub mod abs_path;
 pub mod default_tags;
 pub mod labels;
+pub mod remove_build;
 pub mod secrets;
 pub mod sources;
 #[cfg(feature="hashicorp_vault")]

--- a/src/plugins/transform/remove_build.rs
+++ b/src/plugins/transform/remove_build.rs
@@ -7,6 +7,7 @@ use errors::*;
 use plugins;
 use plugins::{Operation, PluginNew, PluginTransform};
 use project::Project;
+use subcommand::Subcommand;
 
 /// Updates the `labels` in a `dc::File`.
 #[derive(Debug)]
@@ -40,7 +41,7 @@ impl PluginTransform for Plugin {
                  file: &mut dc::File)
                  -> Result<()> {
 
-        if ctx.subcommand != "build" {
+        if ctx.subcommand != Subcommand::Build {
             for service in &mut file.services.values_mut() {
                 service.build = None;
             }
@@ -58,7 +59,7 @@ fn removes_build_for_most_commands() {
 
     let target = proj.current_target();
     let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend, "up");
+    let ctx = plugins::Context::new(&proj, frontend, Subcommand::Up);
     let mut file = frontend.merged_file(target).unwrap();
 
     plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
@@ -76,7 +77,7 @@ fn leaves_build_in_when_building() {
 
     let target = proj.current_target();
     let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend, "build");
+    let ctx = plugins::Context::new(&proj, frontend, Subcommand::Build);
     let mut file = frontend.merged_file(target).unwrap();
 
     plugin.transform(Operation::Output, &ctx, &mut file).unwrap();

--- a/src/plugins/transform/remove_build.rs
+++ b/src/plugins/transform/remove_build.rs
@@ -36,12 +36,15 @@ impl PluginNew for Plugin {
 impl PluginTransform for Plugin {
     fn transform(&self,
                  _op: Operation,
-                 _: &plugins::Context,
+                 ctx: &plugins::Context,
                  file: &mut dc::File)
                  -> Result<()> {
 
-        for service in &mut file.services.values_mut() {
-            service.build = None;
+        // TODO: Test this
+        if ctx.subcommand != "build" {
+            for service in &mut file.services.values_mut() {
+                service.build = None;
+            }
         }
         Ok(())
     }

--- a/src/plugins/transform/remove_build.rs
+++ b/src/plugins/transform/remove_build.rs
@@ -1,0 +1,48 @@
+//! Plugin which removes the `build` field in a in a `dc::File`.
+
+use compose_yml::v2 as dc;
+use std::marker::PhantomData;
+
+use errors::*;
+use plugins;
+use plugins::{Operation, PluginNew, PluginTransform};
+use project::Project;
+
+/// Updates the `labels` in a `dc::File`.
+#[derive(Debug)]
+#[allow(missing_copy_implementations)]
+pub struct Plugin {
+    /// Placeholder field for future hidden fields, to keep this from being
+    /// directly constructable.
+    _placeholder: PhantomData<()>,
+}
+
+impl plugins::Plugin for Plugin {
+    fn name(&self) -> &'static str {
+        Self::plugin_name()
+    }
+}
+
+impl PluginNew for Plugin {
+    fn plugin_name() -> &'static str {
+        "remove_build"
+    }
+
+    fn new(_project: &Project) -> Result<Self> {
+        Ok(Plugin { _placeholder: PhantomData })
+    }
+}
+
+impl PluginTransform for Plugin {
+    fn transform(&self,
+                 _op: Operation,
+                 _: &plugins::Context,
+                 file: &mut dc::File)
+                 -> Result<()> {
+
+        for service in &mut file.services.values_mut() {
+            service.build = None;
+        }
+        Ok(())
+    }
+}

--- a/src/plugins/transform/secrets.rs
+++ b/src/plugins/transform/secrets.rs
@@ -121,7 +121,7 @@ fn injects_secrets_into_services() {
 
     let target = proj.current_target();
     let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend);
+    let ctx = plugins::Context::new(&proj, frontend, "up");
     let mut file = frontend.merged_file(target).unwrap();
     plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
     let web = file.services.get("web").unwrap();

--- a/src/plugins/transform/secrets.rs
+++ b/src/plugins/transform/secrets.rs
@@ -12,6 +12,8 @@ use errors::*;
 use plugins;
 use plugins::{Operation, PluginGenerate, PluginNew, PluginTransform};
 use project::Project;
+#[cfg(test)]
+use subcommand::Subcommand;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_helpers::load_yaml;
 
@@ -121,7 +123,7 @@ fn injects_secrets_into_services() {
 
     let target = proj.current_target();
     let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend, "up");
+    let ctx = plugins::Context::new(&proj, frontend, Subcommand::Up);
     let mut file = frontend.merged_file(target).unwrap();
     plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
     let web = file.services.get("web").unwrap();

--- a/src/plugins/transform/vault.rs
+++ b/src/plugins/transform/vault.rs
@@ -19,6 +19,8 @@ use errors::*;
 use plugins;
 use plugins::{Operation, PluginGenerate, PluginNew, PluginTransform};
 use project::Project;
+#[cfg(test)]
+use subcommand::Subcommand;
 use serde_helpers::load_yaml;
 use util::err;
 
@@ -357,7 +359,7 @@ fn interpolates_policies() {
     let plugin = Plugin::new_with_generator(&proj, Some(vault)).unwrap();
 
     let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend, "up");
+    let ctx = plugins::Context::new(&proj, frontend, Subcommand::Up);
     let mut file = frontend.merged_file(proj.current_target()).unwrap();
     plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
     let web = file.services.get("web").unwrap();
@@ -392,7 +394,7 @@ fn only_applied_in_specified_targets() {
     let plugin = Plugin::new_with_generator(&proj, Some(vault)).unwrap();
 
     let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend, "test");
+    let ctx = plugins::Context::new(&proj, frontend, Subcommand::Test);
     let mut file = frontend.merged_file(target).unwrap();
     plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
     let web = file.services.get("web").unwrap();

--- a/src/plugins/transform/vault.rs
+++ b/src/plugins/transform/vault.rs
@@ -357,7 +357,7 @@ fn interpolates_policies() {
     let plugin = Plugin::new_with_generator(&proj, Some(vault)).unwrap();
 
     let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend);
+    let ctx = plugins::Context::new(&proj, frontend, "up");
     let mut file = frontend.merged_file(proj.current_target()).unwrap();
     plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
     let web = file.services.get("web").unwrap();
@@ -392,7 +392,7 @@ fn only_applied_in_specified_targets() {
     let plugin = Plugin::new_with_generator(&proj, Some(vault)).unwrap();
 
     let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend);
+    let ctx = plugins::Context::new(&proj, frontend, "test");
     let mut file = frontend.merged_file(target).unwrap();
     plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
     let web = file.services.get("web").unwrap();

--- a/src/project.rs
+++ b/src/project.rs
@@ -590,7 +590,7 @@ fn output_creates_a_directory_of_flat_yml_files() {
     use env_logger;
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
-    proj.output().unwrap();
+    proj.output("up").unwrap();
     assert!(proj.output_dir.join("pods").join("frontend.yml").exists());
     assert!(proj.output_dir.join("pods").join("db.yml").exists());
     assert!(proj.output_dir.join("pods").join("rake.yml").exists());
@@ -609,7 +609,7 @@ fn output_applies_expected_transforms() {
     proj.set_default_tags(default_tags);
     let source = proj.sources().find_by_alias("dockercloud-hello-world").unwrap();
     source.fake_clone_source(&proj).unwrap();
-    proj.output().unwrap();
+    proj.output("build").unwrap();
 
     // Load the generated file and look at the `web` service we cloned.
     let frontend_file = proj.output_dir().join("pods").join("frontend.yml");
@@ -649,7 +649,7 @@ fn output_mounts_cloned_libraries() {
         .find_by_lib_key("coffee_rails")
         .expect("should define lib coffee_rails");
     source.fake_clone_source(&proj).unwrap();
-    proj.output().unwrap();
+    proj.output("up").unwrap();
 
     // Load the generated file and look at the `web` service we cloned.
     let frontend_file = proj.output_dir().join("pods").join("frontend.yml");
@@ -671,7 +671,7 @@ fn output_mounts_cloned_libraries() {
 #[test]
 fn output_supports_in_tree_source_code() {
     let proj = Project::from_example("node_hello").unwrap();
-    proj.output().unwrap();
+    proj.output("build").unwrap();
 
     // Load the generated file and look at the `web` service we cloned.
     let frontend_file = proj.output_dir().join("pods").join("frontend.yml");
@@ -721,12 +721,6 @@ fn export_applies_expected_transforms() {
     let frontend_file = export_dir.join("frontend.yml");
     let file = dc::File::read_from_path(frontend_file).unwrap();
     let web = file.services.get("web").unwrap();
-
-    // Make sure our `build` entry has not been pointed at the local source
-    // directory.
-    let url = "https://github.com/docker/dockercloud-hello-world.git";
-    assert_eq!(web.build.as_ref().unwrap().context.value().unwrap(),
-               &dc::Context::new(dc::GitUrl::new(url).unwrap()));
 
     // Make sure we've added our custom labels.
     assert_eq!(web.labels.get("io.fdy.cage.target").unwrap().value().unwrap(),

--- a/src/project.rs
+++ b/src/project.rs
@@ -410,7 +410,7 @@ impl Project {
 
     /// Process our pods, flattening and transforming them using our
     /// plugins, and output them to the specified directory.
-    fn output_helper(&self, op: Operation, export_dir: &Path) -> Result<()> {
+    fn output_helper(&self, op: Operation, subcommand: &str, export_dir: &Path) -> Result<()> {
         // Output each pod.  This isn't especially slow (except maybe the
         // Vault plugin), but parallelizing things is easy.
         self.pods.par_iter()
@@ -439,7 +439,7 @@ impl Project {
                 // output.
                 let mut file = try!(pod.merged_file(&self.current_target));
                 try!(file.make_standalone(&self.pods_dir()));
-                let ctx = plugins::Context::new(self, pod);
+                let ctx = plugins::Context::new(self, pod, subcommand);
                 try!(self.plugins().transform(op, &ctx, &mut file));
                 try!(file.write_to_path(out_path));
                 Ok(())
@@ -451,7 +451,7 @@ impl Project {
 
     /// Delete our existing output and replace it with a processed and
     /// expanded version of our pod definitions.
-    pub fn output(&self) -> Result<()> {
+    pub fn output(&self, subcommand: &str) -> Result<()> {
         // Get a path to our output pods directory (and delete it if it
         // exists).
         let out_pods = self.output_pods_dir();
@@ -460,7 +460,7 @@ impl Project {
                 .map_err(|e| err!("Cannot delete {}: {}", out_pods.display(), e)));
         }
 
-        self.output_helper(Operation::Output, &out_pods)
+        self.output_helper(Operation::Output, subcommand, &out_pods)
     }
 
     /// Export this project (with the specified target applied) as a set
@@ -477,7 +477,7 @@ impl Project {
             warn!("Exporting project without --default-tags");
         }
 
-        self.output_helper(Operation::Export, export_dir)
+        self.output_helper(Operation::Export, "export", export_dir)
     }
 }
 

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,0 +1,121 @@
+//! A cage subcommand
+
+use std::str::FromStr;
+
+/// A cage subcommand
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Subcommand {
+
+    /// The `cage build` subcommand
+    Build,
+
+    /// The `cage exec` subcommand
+    Exec,
+
+    /// The `cage export` subcommand
+    Export,
+
+    /// The `cage generate` subcommand
+    Generate,
+
+    /// The `cage logs` subcommand
+    Logs,
+
+    /// The `cage new` subcommand
+    New,
+
+    /// The `cage pull` subcommand
+    Pull,
+
+    /// The `cage restart` subcommand
+    Restart,
+
+    /// The `cage rm` subcommand
+    Rm,
+
+    /// The `cage run` subcommand
+    Run,
+
+    /// The `cage run-script` subcommand
+    RunScript,
+
+    /// The `cage shell` subcommand
+    Shell,
+
+    /// The `cage source` subcommand
+    Source,
+
+    /// The `cage status` subcommand
+    Status,
+
+    /// The `cage stop` subcommand
+    Stop,
+
+    /// The `cage sysinfo` subcommand
+    Sysinfo,
+
+    /// The `cage test` subcommand
+    Test,
+
+    /// The `cage up` subcommand
+    Up,
+
+    /// The `cage source clone` subcommand
+    Clone,
+
+    /// The `cage source ls` subcommand
+    Ls,
+
+    /// The `cage source mount` subcommand
+    Mount,
+
+    /// The `cage source unmount` subcommand
+    Unmount,
+
+    /// The `cage generate completion` subcommand
+    Completion,
+
+    /// The `cage generate secrets` subcommand
+    Secrets,
+
+    /// The `cage generate vault` subcommand
+    Vault,
+}
+
+impl FromStr for Subcommand {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Subcommand, ()> {
+        match s {
+            "build" => Ok(Subcommand::Build),
+            "exec" => Ok(Subcommand::Exec),
+            "export" => Ok(Subcommand::Export),
+            "generate" => Ok(Subcommand::Generate),
+            "logs" => Ok(Subcommand::Logs),
+            "new" => Ok(Subcommand::New),
+            "pull" => Ok(Subcommand::Pull),
+            "restart" => Ok(Subcommand::Restart),
+            "rm" => Ok(Subcommand::Rm),
+            "run" => Ok(Subcommand::Run),
+            "run-script" => Ok(Subcommand::RunScript),
+            "shell" => Ok(Subcommand::Shell),
+            "source" => Ok(Subcommand::Source),
+            "status" => Ok(Subcommand::Status),
+            "stop" => Ok(Subcommand::Stop),
+            "sysinfo" => Ok(Subcommand::Sysinfo),
+            "test" => Ok(Subcommand::Test),
+            "up" => Ok(Subcommand::Up),
+
+            "clone" => Ok(Subcommand::Clone),
+            "ls" => Ok(Subcommand::Ls),
+            "mount" => Ok(Subcommand::Mount),
+            "unmount" => Ok(Subcommand::Unmount),
+
+            "completion" => Ok(Subcommand::Completion),
+            "secrets" => Ok(Subcommand::Secrets),
+            "vault" => Ok(Subcommand::Vault),
+
+            _ => Err(()),
+        }
+    }
+}

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -61,25 +61,25 @@ pub enum Subcommand {
     Up,
 
     /// The `cage source clone` subcommand
-    Clone,
+    SourceClone,
 
     /// The `cage source ls` subcommand
-    Ls,
+    SourceLs,
 
     /// The `cage source mount` subcommand
-    Mount,
+    SourceMount,
 
     /// The `cage source unmount` subcommand
-    Unmount,
+    SourceUnmount,
 
     /// The `cage generate completion` subcommand
-    Completion,
+    GenerateCompletion,
 
     /// The `cage generate secrets` subcommand
-    Secrets,
+    GenerateSecrets,
 
     /// The `cage generate vault` subcommand
-    Vault,
+    GenerateVault,
 }
 
 impl FromStr for Subcommand {
@@ -106,14 +106,14 @@ impl FromStr for Subcommand {
             "test" => Ok(Subcommand::Test),
             "up" => Ok(Subcommand::Up),
 
-            "clone" => Ok(Subcommand::Clone),
-            "ls" => Ok(Subcommand::Ls),
-            "mount" => Ok(Subcommand::Mount),
-            "unmount" => Ok(Subcommand::Unmount),
+            "clone" => Ok(Subcommand::SourceClone),
+            "ls" => Ok(Subcommand::SourceLs),
+            "mount" => Ok(Subcommand::SourceMount),
+            "unmount" => Ok(Subcommand::SourceUnmount),
 
-            "completion" => Ok(Subcommand::Completion),
-            "secrets" => Ok(Subcommand::Secrets),
-            "vault" => Ok(Subcommand::Vault),
+            "completion" => Ok(Subcommand::GenerateCompletion),
+            "secrets" => Ok(Subcommand::GenerateSecrets),
+            "vault" => Ok(Subcommand::GenerateVault),
 
             _ => Err(()),
         }


### PR DESCRIPTION
Resolves #69. Obviously not intended to be merged as-is, though I have tested it and it does indeed strip the build field as intended.

Just thought I'd throw something out there. It's a pretty naive implementation, involving some copy-paste from the existing labels plugin.

Is this heading in the right direction, or is it way off? 😄