### PR TITLE
Add --no-deps option to run-script command

### DIFF
--- a/src/args/opts.rs
+++ b/src/args/opts.rs
@@ -172,7 +172,7 @@ fn exec_options_to_args_returns_appropriate_flags() {
     assert_eq!(opts.to_args(), expected);
 }
 
-/// Options for `docker_compose exec`.
+/// Options for `docker_compose run`.
 #[derive(Debug, Clone, Default)]
 pub struct Run {
     /// Our "superclass", faked using `Deref`.
@@ -184,6 +184,10 @@ pub struct Run {
     /// Override the container's entrypoint.  Specify `Some("".to_owned())`
     /// to reset the entrypoint to the default.
     pub entrypoint: Option<String>,
+
+    /// Don't start linked services when running specified service,
+    /// default: false
+    pub no_deps: bool,
 
     /// PRIVATE: This field is a stand-in for future options.
     /// See http://stackoverflow.com/q/39277157/12089
@@ -215,6 +219,9 @@ impl ToArgs for Run {
         if let Some(ref entrypoint) = self.entrypoint {
             args.push(OsStr::new("--entrypoint").to_owned());
             args.push(entrypoint.into());
+        }
+        if self.no_deps {
+            args.push(OsStr::new("--no-deps").to_owned());
         }
         args
     }

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -134,6 +134,9 @@ subcommands:
   - run-script:
       about: "Run a named script defined in metadata for specified pods or services"
       args:
+        - no-deps: &nodeps
+            long: "--no-deps"
+            help: "Do not start linked services when running scripts"
         - SCRIPT_NAME:
             value_name: "SCRIPT_NAME"
             required: true

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,7 @@ impl<'a> ArgMatchesExt for clap::ArgMatches<'a> {
                 opts.environment.insert(env_val[0].to_owned(), env_val[1].to_owned());
             }
         }
+        opts.no_deps = self.is_present("no-deps");
         opts
     }
 
@@ -260,10 +261,10 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
             proj.run(&runner, service, cmd.as_ref(), &opts)?;
         }
         "run-script" => {
-            warn_if_pods_are_enabled_but_not_running(&proj)?;
+            let opts = sc_matches.to_run_options();
             let script_name = sc_matches.value_of("SCRIPT_NAME").unwrap();
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", true);
-            proj.run_script(&runner, &acts_on, script_name.as_ref())?;
+            proj.run_script(&runner, &acts_on, script_name.as_ref(), &opts)?;
         }
         "exec" => {
             warn_if_pods_are_enabled_but_not_running(&proj)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,7 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
             proj.run(&runner, service, cmd.as_ref(), &opts)?;
         }
         "run-script" => {
+            warn_if_pods_are_enabled_but_not_running(&proj)?;
             let opts = sc_matches.to_run_options();
             let script_name = sc_matches.value_of("SCRIPT_NAME").unwrap();
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", true);

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -290,10 +290,16 @@ impl Pod {
     }
 
     /// Run a named script for specified service name
-    pub fn run_script<CR>(&self, runner: &CR, project: &Project, service_name: &str, script_name: &str) -> Result<()> 
+    pub fn run_script<CR>(&self,
+                          runner: &CR,
+                          project: &Project,
+                          service_name: &str,
+                          script_name: &str,
+                          opts: &args::opts::Run
+                          ) -> Result<()> 
         where CR: CommandRunner
     {
-        self.config.run_script(runner, &project, &service_name, &script_name)
+        self.config.run_script(runner, &project, &service_name, &script_name, &opts)
     }
 }
 

--- a/src/pod_config.in.rs
+++ b/src/pod_config.in.rs
@@ -55,12 +55,23 @@ struct Config {
 impl Config {
 
     /// Run a named script for the specified service in this pod
-    pub fn run_script<CR>(&self, runner: &CR, project: &Project, service_name: &str, script_name: &str) -> Result<()> 
+    pub fn run_script<CR>(&self,
+                          runner: &CR,
+                          project: &Project,
+                          service_name: &str,
+                          script_name: &str,
+                          opts: &args::opts::Run
+                          ) -> Result<()> 
         where CR: CommandRunner
     {
         match self.services.get(service_name) {
             Some(service_config) => {
-                service_config.run_script(runner, &project, &service_name, &script_name)?
+                service_config.run_script(
+                    runner,
+                    &project,
+                    &service_name,
+                    &script_name,
+                    &opts)?
             },
             None => {}
         }
@@ -81,11 +92,17 @@ struct ServiceConfig {
 impl ServiceConfig {
 
     /// Run a named script for the given service
-    pub fn run_script<CR>(&self, runner: &CR, project: &Project, service_name: &str, script_name: &str) -> Result<()>
+    pub fn run_script<CR>(&self,
+                          runner: &CR,
+                          project: &Project,
+                          service_name: &str,
+                          script_name: &str,
+                          opts: &args::opts::Run
+                          ) -> Result<()>
         where CR: CommandRunner
     {
         if let Some(script) = self.scripts.get(script_name) {
-            script.run(runner, &project, service_name)?;
+            script.run(runner, &project, service_name, &opts)?;
         }
         Ok(())
     }
@@ -98,7 +115,12 @@ struct Script(Vec<Vec<String>>);
 impl Script {
 
     /// Execute each command defined for the named script
-    pub fn run<CR>(&self, runner: &CR, project: &Project, service_name: &str) -> Result<()> 
+    pub fn run<CR>(
+        &self,
+        runner: &CR,
+        project: &Project,
+        service_name: &str,
+        opts: &args::opts::Run) -> Result<()> 
         where CR: CommandRunner
     {
         for cmd in &self.0 {
@@ -111,7 +133,6 @@ impl Script {
             } else {
                 None
             };
-            let opts = args::opts::Run::default();
             project.run(runner, service_name, cmd.as_ref(), &opts)?;
         }
         Ok(())


### PR DESCRIPTION
This utilizes the `docker-compose run --no-deps` flag