### PR TITLE
Upgrade to compose_yml 0.0.49 for port/protocol support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "cli_test_dir 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "compose_yml 0.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compose_yml 0.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "copy_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "compose_yml"
-version = "0.0.48"
+version = "0.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clippy 0.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1058,7 +1058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clippy 0.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "6d51fa3f39b300c58906f8e103bc4c5ee5651f89fbbc46ea1423e2651461b0e7"
 "checksum clippy_lints 0.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "4329699b62341fd3ce3ebe13ade6c87d35b8778091e0c2f6da51399e081b9671"
 "checksum colored 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "351495587858823f438c1f6e4ea854b23e2d33e3c77bbb9d60f0740ef9b27972"
-"checksum compose_yml 0.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "ed0c89de4b748411f050f421624d26d90d119f2c187bda3595933fd4d183f99e"
+"checksum compose_yml 0.0.49 (registry+https://github.com/rust-lang/crates.io-index)" = "9e26445ab77c259c7beb89e587693beb64de58b68b368bf30bef41f937ed487a"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum copy_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e4281031634644843bd2f5aa9c48cf98fc48d6b083bd90bb11becf10deaf8b0"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ boondock = { version = "0.0.47", default-features = false }
 clap = { version = "2.14.0", features = ["yaml"] }
 clippy = { version = "0.0.*", optional = true }
 colored = "1.3.1"
-compose_yml = { version = "0.0.48", default-features = false }
+compose_yml = { version = "0.0.49", default-features = false }
 env_logger = "0.3.4"
 error-chain = "0.5.0"
 glob = "0.2.11"

--- a/src/plugins/transform/vault.rs
+++ b/src/plugins/transform/vault.rs
@@ -284,7 +284,7 @@ impl PluginTransform for Plugin {
         }
 
         // Apply to each service.
-        for (name, mut service) in &mut file.services {
+        for (name, service) in &mut file.services {
             // Set up a ConfigEnvironment that we can use to perform
             // interpolations of values like `$SERVICE` in our config file.
             let env = ConfigEnvironment {


### PR DESCRIPTION
For feature #75, release #76.

Also fixed a warning from an unnecessary `mut` in the vault plugin.