### PR TITLE
Strip the `build` field, revised

### DIFF
--- a/src/cmd/compose.rs
+++ b/src/cmd/compose.rs
@@ -109,7 +109,7 @@ fn runs_docker_compose_on_all_pods() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("stop").unwrap();
 
     let opts = args::opts::Empty;
     proj.compose(&runner, "stop", &args::ActOn::All, &opts).unwrap();
@@ -143,7 +143,7 @@ fn runs_docker_compose_on_named_pods_and_services() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("stop").unwrap();
 
     let act_on = args::ActOn::Named(vec!("db".to_owned(), "web".to_owned()));
     let opts = args::opts::Empty;

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -80,7 +80,7 @@ fn invokes_docker_exec() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("exec").unwrap();
 
     let command = args::Command::new("true");
     let mut opts = args::opts::Exec::default();
@@ -108,7 +108,7 @@ fn runs_shells() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("exec").unwrap();
 
     proj.shell(&runner, "web", &Default::default()).unwrap();
 

--- a/src/cmd/logs.rs
+++ b/src/cmd/logs.rs
@@ -42,7 +42,7 @@ fn runs_docker_compose_logs() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("logs").unwrap();
 
     let opts = args::opts::Logs::default();
     proj.logs(&runner,
@@ -67,7 +67,7 @@ fn errors_when_act_on_specifies_multiple_containers() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("logs").unwrap();
 
     let opts = args::opts::Logs::default();
     assert!(proj.logs(&runner, &args::ActOn::All, &opts).is_err());

--- a/src/cmd/pull.rs
+++ b/src/cmd/pull.rs
@@ -36,7 +36,7 @@ fn runs_docker_compose_pull_on_all_pods() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("pull").unwrap();
 
     proj.pull(&runner, &args::ActOn::All).unwrap();
     assert_ran!(runner, {

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -99,7 +99,7 @@ fn fails_on_a_multi_service_pod() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("run").unwrap();
     let opts = Default::default();
     assert!(proj.run(&runner, "frontend", None, &opts).is_err());
 }
@@ -110,7 +110,7 @@ fn runs_a_single_service_pod() {
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("run").unwrap();
     let cmd = args::Command::new("db:migrate");
     let mut opts = args::opts::Run::default();
     opts.allocate_tty = false;
@@ -136,7 +136,7 @@ fn runs_tests() {
     let mut proj = Project::from_example("hello").unwrap();
     proj.set_current_target_name("test").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("test").unwrap();
 
     proj.test(&runner, "frontend/proxy", None).unwrap();
 
@@ -164,7 +164,7 @@ fn runs_tests_with_custom_command() {
     let mut proj = Project::from_example("hello").unwrap();
     proj.set_current_target_name("test").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("test").unwrap();
 
     let cmd = args::Command::new("rspec").with_args(&["-t", "foo"]);
     proj.test(&runner, "proxy", Some(&cmd)).unwrap();

--- a/src/cmd/run_script.rs
+++ b/src/cmd/run_script.rs
@@ -62,7 +62,7 @@ fn runs_scripts_on_all_services() {
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
     let opts = args::opts::Run::default();
-    proj.output().unwrap();
+    proj.output("run-script").unwrap();
 
     proj.run_script(&runner, &args::ActOn::All, "routes", &opts).unwrap();
     assert_ran!(runner, {

--- a/src/cmd/up.rs
+++ b/src/cmd/up.rs
@@ -124,7 +124,7 @@ fn runs_docker_compose_up_honors_enable_in_targets() {
     let mut proj = Project::from_example("rails_hello").unwrap();
     proj.set_current_target_name("production").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("up").unwrap();
 
     let opts = args::opts::Up::default();
     proj.up(&runner, &args::ActOn::All, &opts).unwrap();

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -93,7 +93,7 @@ fn runs_requested_hook_scripts() {
     let _ = env_logger::init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
-    proj.output().unwrap();
+    proj.output("pull").unwrap();
 
     proj.hooks().invoke(&runner, "pull", &BTreeMap::default()).unwrap();
     assert_ran!(runner, {

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,7 +212,7 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Output our project's `*.yml` files for `docker-compose` if we'll
     // need it.
     if matches.should_output_project() {
-        proj.output()?;
+        proj.output(sc_name)?;
     }
 
     // Handle our subcommands that require a `Project`.
@@ -337,7 +337,7 @@ fn run_source<R>(runner: &R,
 
     // Regenerate our output if it might have changed.
     if re_output {
-        proj.output()?;
+        proj.output(sc_name)?;
     }
 
     Ok(())

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -19,16 +19,19 @@ pub struct Context<'a> {
     pub project: &'a Project,
     /// The pod to which we're applying this plugin.
     pub pod: &'a Pod,
+    /// The subcommand to which we're applying this plugin.
+    pub subcommand: String,
     /// PRIVATE. Allow future extensibility without breaking the API.
     _nonexclusive: PhantomData<()>,
 }
 
 impl<'a> Context<'a> {
     /// Create a new plugin context.
-    pub fn new(project: &'a Project, pod: &'a Pod) -> Context<'a> {
+    pub fn new(project: &'a Project, pod: &'a Pod, subcommand: &str) -> Context<'a> {
         Context {
             project: project,
             pod: pod,
+            subcommand: subcommand.to_string(),
             _nonexclusive: PhantomData,
         }
     }
@@ -129,6 +132,7 @@ impl Manager {
         manager.register_transform::<transform::default_tags::Plugin>(proj)?;
         manager.register_transform::<transform::sources::Plugin>(proj)?;
         manager.register_transform::<transform::secrets::Plugin>(proj)?;
+        manager.register_transform::<transform::remove_build::Plugin>(proj)?;
         manager.register_vault_transform(proj)?;
 
         // Run this last, in case it wants to remove any labels used by

--- a/src/plugins/transform/mod.rs
+++ b/src/plugins/transform/mod.rs
@@ -3,6 +3,7 @@
 pub mod abs_path;
 pub mod default_tags;
 pub mod labels;
+pub mod remove_build;
 pub mod secrets;
 pub mod sources;
 #[cfg(feature="hashicorp_vault")]

--- a/src/plugins/transform/remove_build.rs
+++ b/src/plugins/transform/remove_build.rs
@@ -1,0 +1,86 @@
+//! Plugin which removes the `build` field in a in a `dc::File`.
+
+use compose_yml::v2 as dc;
+use std::marker::PhantomData;
+
+use errors::*;
+use plugins;
+use plugins::{Operation, PluginNew, PluginTransform};
+use project::Project;
+
+/// Updates the `labels` in a `dc::File`.
+#[derive(Debug)]
+#[allow(missing_copy_implementations)]
+pub struct Plugin {
+    /// Placeholder field for future hidden fields, to keep this from being
+    /// directly constructable.
+    _placeholder: PhantomData<()>,
+}
+
+impl plugins::Plugin for Plugin {
+    fn name(&self) -> &'static str {
+        Self::plugin_name()
+    }
+}
+
+impl PluginNew for Plugin {
+    fn plugin_name() -> &'static str {
+        "remove_build"
+    }
+
+    fn new(_project: &Project) -> Result<Self> {
+        Ok(Plugin { _placeholder: PhantomData })
+    }
+}
+
+impl PluginTransform for Plugin {
+    fn transform(&self,
+                 _op: Operation,
+                 ctx: &plugins::Context,
+                 file: &mut dc::File)
+                 -> Result<()> {
+
+        if ctx.subcommand != "build" {
+            for service in &mut file.services.values_mut() {
+                service.build = None;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn removes_build_for_most_commands() {
+    use env_logger;
+    let _ = env_logger::init();
+    let proj = Project::from_example("rails_hello").unwrap();
+    let plugin = Plugin::new(&proj).unwrap();
+
+    let target = proj.current_target();
+    let frontend = proj.pod("frontend").unwrap();
+    let ctx = plugins::Context::new(&proj, frontend, "up");
+    let mut file = frontend.merged_file(target).unwrap();
+
+    plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
+
+    let web = file.services.get("web").unwrap();
+    assert_eq!(web.build, None);
+}
+
+#[test]
+fn leaves_build_in_when_building() {
+    use env_logger;
+    let _ = env_logger::init();
+    let proj = Project::from_example("rails_hello").unwrap();
+    let plugin = Plugin::new(&proj).unwrap();
+
+    let target = proj.current_target();
+    let frontend = proj.pod("frontend").unwrap();
+    let ctx = plugins::Context::new(&proj, frontend, "build");
+    let mut file = frontend.merged_file(target).unwrap();
+
+    plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
+
+    let web = file.services.get("web").unwrap();
+    assert!(web.build != None);
+}

--- a/src/plugins/transform/secrets.rs
+++ b/src/plugins/transform/secrets.rs
@@ -121,7 +121,7 @@ fn injects_secrets_into_services() {
 
     let target = proj.current_target();
     let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend);
+    let ctx = plugins::Context::new(&proj, frontend, "up");
     let mut file = frontend.merged_file(target).unwrap();
     plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
     let web = file.services.get("web").unwrap();

--- a/src/plugins/transform/vault.rs
+++ b/src/plugins/transform/vault.rs
@@ -357,7 +357,7 @@ fn interpolates_policies() {
     let plugin = Plugin::new_with_generator(&proj, Some(vault)).unwrap();
 
     let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend);
+    let ctx = plugins::Context::new(&proj, frontend, "up");
     let mut file = frontend.merged_file(proj.current_target()).unwrap();
     plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
     let web = file.services.get("web").unwrap();
@@ -392,7 +392,7 @@ fn only_applied_in_specified_targets() {
     let plugin = Plugin::new_with_generator(&proj, Some(vault)).unwrap();
 
     let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend);
+    let ctx = plugins::Context::new(&proj, frontend, "test");
     let mut file = frontend.merged_file(target).unwrap();
     plugin.transform(Operation::Output, &ctx, &mut file).unwrap();
     let web = file.services.get("web").unwrap();

--- a/src/project.rs
+++ b/src/project.rs
@@ -410,7 +410,7 @@ impl Project {
 
     /// Process our pods, flattening and transforming them using our
     /// plugins, and output them to the specified directory.
-    fn output_helper(&self, op: Operation, export_dir: &Path) -> Result<()> {
+    fn output_helper(&self, op: Operation, subcommand: &str, export_dir: &Path) -> Result<()> {
         // Output each pod.  This isn't especially slow (except maybe the
         // Vault plugin), but parallelizing things is easy.
         self.pods.par_iter()
@@ -439,7 +439,7 @@ impl Project {
                 // output.
                 let mut file = try!(pod.merged_file(&self.current_target));
                 try!(file.make_standalone(&self.pods_dir()));
-                let ctx = plugins::Context::new(self, pod);
+                let ctx = plugins::Context::new(self, pod, subcommand);
                 try!(self.plugins().transform(op, &ctx, &mut file));
                 try!(file.write_to_path(out_path));
                 Ok(())
@@ -451,7 +451,7 @@ impl Project {
 
     /// Delete our existing output and replace it with a processed and
     /// expanded version of our pod definitions.
-    pub fn output(&self) -> Result<()> {
+    pub fn output(&self, subcommand: &str) -> Result<()> {
         // Get a path to our output pods directory (and delete it if it
         // exists).
         let out_pods = self.output_pods_dir();
@@ -460,7 +460,7 @@ impl Project {
                 .map_err(|e| err!("Cannot delete {}: {}", out_pods.display(), e)));
         }
 
-        self.output_helper(Operation::Output, &out_pods)
+        self.output_helper(Operation::Output, subcommand, &out_pods)
     }
 
     /// Export this project (with the specified target applied) as a set
@@ -477,7 +477,7 @@ impl Project {
             warn!("Exporting project without --default-tags");
         }
 
-        self.output_helper(Operation::Export, export_dir)
+        self.output_helper(Operation::Export, "export", export_dir)
     }
 }
 
@@ -590,7 +590,7 @@ fn output_creates_a_directory_of_flat_yml_files() {
     use env_logger;
     let _ = env_logger::init();
     let proj = Project::from_example("rails_hello").unwrap();
-    proj.output().unwrap();
+    proj.output("up").unwrap();
     assert!(proj.output_dir.join("pods").join("frontend.yml").exists());
     assert!(proj.output_dir.join("pods").join("db.yml").exists());
     assert!(proj.output_dir.join("pods").join("rake.yml").exists());
@@ -609,7 +609,7 @@ fn output_applies_expected_transforms() {
     proj.set_default_tags(default_tags);
     let source = proj.sources().find_by_alias("dockercloud-hello-world").unwrap();
     source.fake_clone_source(&proj).unwrap();
-    proj.output().unwrap();
+    proj.output("build").unwrap();
 
     // Load the generated file and look at the `web` service we cloned.
     let frontend_file = proj.output_dir().join("pods").join("frontend.yml");
@@ -649,7 +649,7 @@ fn output_mounts_cloned_libraries() {
         .find_by_lib_key("coffee_rails")
         .expect("should define lib coffee_rails");
     source.fake_clone_source(&proj).unwrap();
-    proj.output().unwrap();
+    proj.output("up").unwrap();
 
     // Load the generated file and look at the `web` service we cloned.
     let frontend_file = proj.output_dir().join("pods").join("frontend.yml");
@@ -671,7 +671,7 @@ fn output_mounts_cloned_libraries() {
 #[test]
 fn output_supports_in_tree_source_code() {
     let proj = Project::from_example("node_hello").unwrap();
-    proj.output().unwrap();
+    proj.output("build").unwrap();
 
     // Load the generated file and look at the `web` service we cloned.
     let frontend_file = proj.output_dir().join("pods").join("frontend.yml");
@@ -721,12 +721,6 @@ fn export_applies_expected_transforms() {
     let frontend_file = export_dir.join("frontend.yml");
     let file = dc::File::read_from_path(frontend_file).unwrap();
     let web = file.services.get("web").unwrap();
-
-    // Make sure our `build` entry has not been pointed at the local source
-    // directory.
-    let url = "https://github.com/docker/dockercloud-hello-world.git";
-    assert_eq!(web.build.as_ref().unwrap().context.value().unwrap(),
-               &dc::Context::new(dc::GitUrl::new(url).unwrap()));
 
     // Make sure we've added our custom labels.
     assert_eq!(web.labels.get("io.fdy.cage.target").unwrap().value().unwrap(),

--- a/src/project.rs
+++ b/src/project.rs
@@ -722,6 +722,10 @@ fn export_applies_expected_transforms() {
     let file = dc::File::read_from_path(frontend_file).unwrap();
     let web = file.services.get("web").unwrap();
 
+    // Make sure our `build` entry has not been pointed at the local source
+    // directory.
+    assert!(web.build.is_none());
+
     // Make sure we've added our custom labels.
     assert_eq!(web.labels.get("io.fdy.cage.target").unwrap().value().unwrap(),
                "development");


### PR DESCRIPTION
This is a version of @camjackson's patch from #70 with the `Subcommand` enum removed, and the `run-script` fix reapplied manually. I also squashed the patches, because the individual patches in the history included several with broken tests.