### PR TITLE
Handle compose_yml changes for valueless keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
  "cli_test_dir 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.176 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "compose_yml 0.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compose_yml 0.0.52",
  "copy_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -220,7 +220,6 @@ dependencies = [
 [[package]]
 name = "compose_yml"
 version = "0.0.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1240,7 +1239,6 @@ dependencies = [
 "checksum clippy_lints 0.0.176 (registry+https://github.com/rust-lang/crates.io-index)" = "41a8d1856b660dae1e2f15ec3a6321f5548eae902b9fc4c8b12596ac9f769162"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0aa3473e85a3161b59845d6096b289bb577874cafeaf75ea1b1beaa6572c7fc"
-"checksum compose_yml 0.0.52 (registry+https://github.com/rust-lang/crates.io-index)" = "c22fec933335fa3c2cb16ddcf813c762900967cf117fa27f8d02ced9272a4078"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum copy_dir 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e4281031634644843bd2f5aa9c48cf98fc48d6b083bd90bb11becf10deaf8b0"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ boondock = { version = "0.0.49", default-features = false }
 clap = { version = "2.14", features = ["yaml"] }
 clippy = { version = "0.0.*", optional = true }
 colored = "1.3"
-compose_yml = "0.0.52"
+compose_yml = { path = "../compose_yml" }
 env_logger = "0.4"
 error-chain = "0.5"
 glob = "0.2"

--- a/src/plugins/transform/labels.rs
+++ b/src/plugins/transform/labels.rs
@@ -48,10 +48,10 @@ impl PluginTransform for Plugin {
             let target = ctx.project.current_target().name();
             service
                 .labels
-                .insert("io.fdy.cage.target".into(), dc::value(target.into()));
+                .insert("io.fdy.cage.target".into(), Some(dc::value(target.into())));
             service
                 .labels
-                .insert("io.fdy.cage.pod".into(), dc::value(ctx.pod.name().into()));
+                .insert("io.fdy.cage.pod".into(), Some(dc::value(ctx.pod.name().into())));
 
             // TODO LOW: Remove metadata-only `io.fdy.cage.` labels?
         }

--- a/src/plugins/transform/secrets_config.in.rs
+++ b/src/plugins/transform/secrets_config.in.rs
@@ -9,11 +9,11 @@ struct ServiceSecrets {
 }
 
 impl ServiceSecrets {
-    fn to_compose_env(&self) -> BTreeMap<String, dc::RawOr<String>> {
+    fn to_compose_env(&self) -> BTreeMap<String, Option<dc::RawOr<String>>> {
         let mut env = BTreeMap::new();
         for (var, val) in &self.secrets {
             let val = dc::escape(val).expect("escape string should never fail");
-            env.insert(var.to_owned(), val);
+            env.insert(var.to_owned(), Some(val));
         }
         env
     }

--- a/src/plugins/transform/vault.rs
+++ b/src/plugins/transform/vault.rs
@@ -313,7 +313,7 @@ impl PluginTransform for Plugin {
             // Insert our VAULT_ADDR value into the generated files.
             service
                 .environment
-                .insert("VAULT_ADDR".to_owned(), dc::escape(generator.addr())?);
+                .insert("VAULT_ADDR".to_owned(), Some(dc::escape(generator.addr())?));
 
             // Get a list of policy "patterns" that apply to this service.
             let mut raw_policies = config.default_policies.clone();
@@ -351,13 +351,13 @@ impl PluginTransform for Plugin {
                 .chain_err(|| format!("could not generate token for '{}'", name))?;
             service
                 .environment
-                .insert("VAULT_TOKEN".to_owned(), dc::escape(token)?);
+                .insert("VAULT_TOKEN".to_owned(), Some(dc::escape(token)?));
 
             // Add in any extra environment variables.
             for (var, val) in &config.extra_environment {
                 service
                     .environment
-                    .insert(var.to_owned(), dc::escape(interpolated(val)?)?);
+                    .insert(var.to_owned(), Some(dc::escape(interpolated(val)?)?));
             }
         }
         Ok(())


### PR DESCRIPTION
This fixes cage to work after emk/compose_yml#12.