### PR TITLE
Hide warnings from compose_yml validations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -411,6 +411,7 @@ fn main() {
     // our own warnings.
     let mut builder = env_logger::LogBuilder::new();
     builder.filter(Some("compose_yml"), log::LogLevelFilter::Warn);
+    builder.filter(Some("compose_yml::v2::validate"), log::LogLevelFilter::Error);
     builder.filter(Some("cage"), log::LogLevelFilter::Warn);
     builder.format(|record: &log::LogRecord| {
         let msg = format!(


### PR DESCRIPTION
Continuing the discussion from emk/compose_yml#11 a couple of months ago...

At this point it seems like the underlying libraries are unlikely to be updated by their original maintainers. Obviously it would be better to get the validations working again in compose_yml, but in the meantime Cage is left with a lot of unpleasant noise in the console on every command.

Would you be ok with hiding these warnings from Cage users?