### PR TITLE
Multiple monorepo tweaks

### DIFF
--- a/src/args/act_on.rs
+++ b/src/args/act_on.rs
@@ -49,7 +49,7 @@ fn all_except_tasks(pod: &&Pod) -> bool {
 enum State<'a> {
     /// This corresponds to `ActOn::All`.
     PodIter(Pods<'a>),
-    /// This corresponds to `ActOn::All`.
+    /// This corresponds to `ActOn::AllExceptTasks`.
     FilteredPodIter(Filter<Pods<'a>, fn(&&Pod) -> bool>),
     /// This corresponds to `ActOn::Named`.
     NameIter(slice::Iter<'a, String>),

--- a/src/args/act_on_sources.rs
+++ b/src/args/act_on_sources.rs
@@ -1,0 +1,36 @@
+//! What sources should a command act on?
+
+use std::{collections::BTreeSet, iter::FromIterator};
+
+use crate::sources::{Source, Sources};
+
+/// What sources do we want to operate on?
+#[derive(Debug)]
+pub enum ActOnSources {
+    /// All our sources.
+    All,
+    /// Only the specified sources. Names that do not correspond to any source
+    /// will be ignored, so check that before getting here.
+    Named(Vec<String>),
+}
+
+impl ActOnSources {
+    /// Iterate over the pods or services specified by this `ActOn` object.
+    pub fn sources_mut<'a>(
+        &'a self,
+        sources: &'a mut Sources,
+    ) -> impl Iterator<Item = &'a mut Source> + 'a {
+        match self {
+            ActOnSources::All => Box::new(sources.iter_mut())
+                as Box<dyn Iterator<Item = &'a mut Source> + 'a>,
+            ActOnSources::Named(aliases) => {
+                let aliases = BTreeSet::from_iter(aliases.iter().cloned());
+                Box::new(
+                    sources
+                        .iter_mut()
+                        .filter(move |source| aliases.contains(source.alias())),
+                )
+            }
+        }
+    }
+}

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -4,9 +4,11 @@
 use std::ffi::OsString;
 
 pub use self::act_on::ActOn;
+pub use self::act_on_sources::ActOnSources;
 pub use self::cmd::*;
 
 pub mod act_on;
+pub mod act_on_sources;
 mod cmd;
 pub mod opts;
 

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -208,7 +208,6 @@ subcommands:
             help: "Number of lines from end of output to display"
         - POD_OR_SERVICE: *pod_or_service
 
-
   - source:
       about: "Commands for working with git repositories and local source trees"
       settings:
@@ -219,18 +218,33 @@ subcommands:
         - clone:
             about: "Clone a git repository using its short alias and mount it into the containers that use it"
             args:
-              - ALIAS: &alias
+              - ALIAS:
                   value_name: "ALIAS"
                   required: true
                   help: "The short alias of the repo to clone (see `source list`)"
         - mount:
             about: "Mount a source tree into the containers that use it"
-            args:
-              - ALIAS: *alias
+            args: &mount_args
+              - ALIASES:
+                  value_name: "ALIASES"
+                  multiple: true
+                  min_values: 1
+                  help: "The short aliases of the source trees to operate on (see `source list`)"
+              - ALL:
+                  long: "all"
+                  short: "a"
+                  help: "Operate on all source trees"
+            groups: &mount_groups
+              - sources:
+                  # Make these arguments mutally exclusive.
+                  args:
+                    - ALIASES
+                    - ALL
+                  required: true
         - unmount:
             about: "Unmount a local source tree from all containers"
-            args:
-              - ALIAS: *alias
+            args: *mount_args
+            groups: *mount_groups
   - generate:
       about: "Commands for generating new source files"
       settings:

--- a/src/cmd/compose.rs
+++ b/src/cmd/compose.rs
@@ -119,7 +119,6 @@ impl CommandCompose for Project {
 
 #[test]
 fn runs_docker_compose_on_all_pods() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
@@ -154,7 +153,6 @@ fn runs_docker_compose_on_all_pods() {
 
 #[test]
 fn runs_docker_compose_on_named_pods_and_services() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -85,7 +85,6 @@ impl CommandExec for Project {
 
 #[test]
 fn invokes_docker_exec() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
@@ -115,7 +114,6 @@ fn invokes_docker_exec() {
 
 #[test]
 fn runs_shells() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();

--- a/src/cmd/logs.rs
+++ b/src/cmd/logs.rs
@@ -42,7 +42,6 @@ impl CommandLogs for Project {
 
 #[test]
 fn runs_docker_compose_logs() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
@@ -71,7 +70,6 @@ fn runs_docker_compose_logs() {
 
 #[test]
 fn errors_when_act_on_specifies_multiple_containers() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();

--- a/src/cmd/pull.rs
+++ b/src/cmd/pull.rs
@@ -34,7 +34,6 @@ impl CommandPull for Project {
 
 #[test]
 fn runs_docker_compose_pull_on_all_pods() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -76,11 +76,12 @@ impl CommandRun for Project {
         // If we don't have any mounted sources, warn.
         let service = pod.service_or_err(target, service_name)?;
         let sources = service.sources(self.sources())?.collect::<Vec<_>>();
+        let sources_dirs = self.sources_dirs();
         let mount_count = sources
             .iter()
             .cloned()
             .filter(|ref source_mount| {
-                source_mount.source.is_available_locally(self)
+                source_mount.source.is_available_locally(&sources_dirs)
                     && source_mount.source.mounted()
             })
             .count();
@@ -112,7 +113,6 @@ impl CommandRun for Project {
 
 #[test]
 fn fails_on_a_multi_service_pod() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();
@@ -123,7 +123,6 @@ fn fails_on_a_multi_service_pod() {
 
 #[test]
 fn runs_a_single_service_pod() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();
@@ -150,7 +149,6 @@ fn runs_a_single_service_pod() {
 
 #[test]
 fn runs_tests() {
-    use env_logger;
     let _ = env_logger::try_init();
     let mut proj = Project::from_example("hello").unwrap();
     proj.set_current_target_name("test").unwrap();
@@ -180,7 +178,6 @@ fn runs_tests() {
 
 #[test]
 fn runs_tests_with_custom_command() {
-    use env_logger;
     let _ = env_logger::try_init();
     let mut proj = Project::from_example("hello").unwrap();
     proj.set_current_target_name("test").unwrap();

--- a/src/cmd/run_script.rs
+++ b/src/cmd/run_script.rs
@@ -71,7 +71,6 @@ impl CommandRunScript for Project {
 
 #[test]
 fn runs_scripts_on_all_services() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("rails_hello").unwrap();
     let runner = TestCommandRunner::new();

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -123,9 +123,10 @@ impl Project {
             .sources(self.sources())?
             .map(|source_mount| Ok(source_mount.source))
             .collect::<Result<_>>()?;
+        let sources_dirs = self.sources_dirs();
         let source_names: Vec<&str> = sources
             .iter()
-            .filter(|s| s.is_available_locally(self) && s.mounted())
+            .filter(|s| s.is_available_locally(&sources_dirs) && s.mounted())
             .map(|s| s.alias())
             .collect();
         if !source_names.is_empty() {

--- a/src/cmd/up.rs
+++ b/src/cmd/up.rs
@@ -128,7 +128,6 @@ impl CommandUp for Project {
 
 #[test]
 fn runs_docker_compose_up_honors_enable_in_targets() {
-    use env_logger;
     let _ = env_logger::try_init();
     let mut proj = Project::from_example("rails_hello").unwrap();
     proj.set_current_target_name("production").unwrap();

--- a/src/ext/service.rs
+++ b/src/ext/service.rs
@@ -179,7 +179,6 @@ impl<'a> Iterator for Sources<'a> {
 
 #[test]
 fn src_dir_returns_the_source_directory_for_this_service() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj: Project = Project::from_example("rails_hello").unwrap();
     let target = proj.target("development").unwrap();
@@ -199,7 +198,6 @@ fn src_dir_returns_the_source_directory_for_this_service() {
 
 #[test]
 fn build_context_can_specify_a_subdirectory() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj: Project = Project::from_fixture("with_repo_subdir").unwrap();
     let target = proj.target("development").unwrap();
@@ -222,7 +220,6 @@ fn build_context_can_specify_a_subdirectory() {
 
 #[test]
 fn shell_returns_preferred_shell_for_this_service() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj: Project = Project::from_example("hello").unwrap();
     let target = proj.target("development").unwrap();

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -94,7 +94,6 @@ impl HookManager {
 
 #[test]
 fn runs_requested_hook_scripts() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("hello").unwrap();
     let runner = TestCommandRunner::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,24 @@
 //! Our main CLI tool.
 
-use cage;
 #[macro_use]
 extern crate clap;
-use colored;
-
 #[macro_use]
 extern crate log;
-use openssl_probe;
 
+use cage::{
+    cmd::*,
+    command_runner::{Command, CommandRunner, OsCommandRunner},
+    ErrorKind, Project, Result,
+};
 use colored::Colorize;
 use itertools::Itertools;
-use std::env;
-use std::fs;
-use std::io::{self, Write};
-use std::path::Path;
-use std::process;
+use std::{
+    env, fs,
+    io::{self, Write},
+    path::Path,
+    process,
+};
 use yaml_rust::yaml;
-
-use cage::cmd::*;
-use cage::command_runner::{Command, CommandRunner, OsCommandRunner};
-use cage::Result;
 
 /// Load our command-line interface definitions from an external `clap`
 /// YAML file.  We could create these using code, but at the cost of more
@@ -40,6 +38,12 @@ trait ArgMatchesExt {
 
     /// Determine what pods or services we're supposed to act on.
     fn to_acts_on(&self, arg_name: &str, include_tasks: bool) -> cage::args::ActOn;
+
+    /// Determine what sources we're supposed to act on.
+    fn to_acts_on_sources(
+        &self,
+        project: &Project,
+    ) -> Result<cage::args::ActOnSources>;
 
     /// Extract options shared by `exec` and `run` from our command-line
     /// arguments.
@@ -91,6 +95,26 @@ impl<'a> ArgMatchesExt for clap::ArgMatches<'a> {
             }
         } else {
             cage::args::ActOn::Named(names)
+        }
+    }
+
+    /// Determine what pods or services we're supposed to act on.
+    fn to_acts_on_sources(&self, proj: &Project) -> Result<cage::args::ActOnSources> {
+        if self.is_present("ALL") {
+            Ok(cage::args::ActOnSources::All)
+        } else if let Some(aliases) = self.values_of("ALIASES") {
+            let aliases = aliases
+                .map(|a| -> Result<String> {
+                    if proj.sources().find_by_alias(a).is_none() {
+                        Err(ErrorKind::UnknownSource(a.to_owned()).into())
+                    } else {
+                        Ok(a.to_owned())
+                    }
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(cage::args::ActOnSources::Named(aliases))
+        } else {
+            panic!("clap source always require --all or a list of sources");
         }
     }
 
@@ -326,12 +350,12 @@ where
             proj.source_clone(runner, alias)?;
         }
         "mount" => {
-            let alias = sc_matches.value_of("ALIAS").unwrap();
-            proj.source_set_mounted(runner, alias, true)?;
+            let act_on_sources = sc_matches.to_acts_on_sources(proj)?;
+            proj.source_set_mounted(runner, act_on_sources, true)?;
         }
         "unmount" => {
-            let alias = sc_matches.value_of("ALIAS").unwrap();
-            proj.source_set_mounted(runner, alias, false)?;
+            let act_on_sources = sc_matches.to_acts_on_sources(proj)?;
+            proj.source_set_mounted(runner, act_on_sources, false)?;
         }
         unknown => unreachable!("Unexpected subcommand '{}'", unknown),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ use cage;
 #[macro_use]
 extern crate clap;
 use colored;
-use env_logger;
 
 #[macro_use]
 extern crate log;

--- a/src/plugins/transform/abs_path.rs
+++ b/src/plugins/transform/abs_path.rs
@@ -92,7 +92,6 @@ impl PluginTransform for Plugin {
 //
 // #[test]
 // fn converts_relative_paths_to_absolute() {
-//     use env_logger;
 //     let _ = env_logger::try_init();
 //     let proj = Project::from_example("rails_hello").unwrap();
 //     proj.output().unwrap();

--- a/src/plugins/transform/remove_build.rs
+++ b/src/plugins/transform/remove_build.rs
@@ -53,7 +53,6 @@ impl PluginTransform for Plugin {
 
 #[test]
 fn removes_build_for_most_commands() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("rails_hello").unwrap();
     let plugin = Plugin::new(&proj).unwrap();
@@ -73,7 +72,6 @@ fn removes_build_for_most_commands() {
 
 #[test]
 fn leaves_build_in_when_building() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("rails_hello").unwrap();
     let plugin = Plugin::new(&proj).unwrap();

--- a/src/plugins/transform/secrets.rs
+++ b/src/plugins/transform/secrets.rs
@@ -180,7 +180,6 @@ impl PluginTransform for Plugin {
 
 #[test]
 fn enabled_for_projects_with_config_file() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj1 = Project::from_example("hello").unwrap();
     assert!(!Plugin::is_configured_for(&proj1).unwrap());
@@ -190,7 +189,6 @@ fn enabled_for_projects_with_config_file() {
 
 #[test]
 fn injects_secrets_into_services() {
-    use env_logger;
     let _ = env_logger::try_init();
     let mut proj = Project::from_example("rails_hello").unwrap();
     proj.set_current_target_name("production").unwrap();

--- a/src/plugins/transform/vault.rs
+++ b/src/plugins/transform/vault.rs
@@ -705,7 +705,6 @@ mod test {
 
     #[test]
     fn only_applied_in_specified_targets() {
-        use env_logger;
         let _ = env_logger::try_init();
 
         let mut proj = Project::from_example("vault_integration").unwrap();

--- a/src/plugins/transform/vault.rs
+++ b/src/plugins/transform/vault.rs
@@ -1,24 +1,24 @@
 //! Plugin which issues vault tokens to services.
 
 use compose_yml::v2 as dc;
-use std::collections::BTreeMap;
-use std::env;
-use std::fmt::Debug;
-use std::fs;
-use std::io::{self, Read};
-#[cfg(test)]
-use std::path::Path;
-use std::path::PathBuf;
-use std::result;
-#[cfg(test)]
-use std::sync::{Arc, RwLock};
+use std::{
+    collections::{btree_map::Entry, BTreeMap, BTreeSet},
+    env,
+    fmt::Debug,
+    fs,
+    io::{self, Read},
+    path::PathBuf,
+    result,
+    time::{Duration, SystemTime},
+};
 use vault::client::VaultDuration;
 
 use crate::errors::*;
 use crate::plugins;
 use crate::plugins::{Operation, PluginGenerate, PluginNew, PluginTransform};
+use crate::pod::Pod;
 use crate::project::Project;
-use crate::serde_helpers::load_yaml;
+use crate::serde_helpers::{dump_yaml, load_yaml, seconds_since_epoch};
 use crate::util::err;
 
 /// How should our applications authenticate themselves with vault?
@@ -76,6 +76,7 @@ struct Config {
 
 #[test]
 fn can_deserialize_config() {
+    use std::path::Path;
     let path = Path::new("examples/vault_integration/config/vault.yml");
     let config: Config = load_yaml(&path).unwrap();
     assert_eq!(config.auth_type, AuthType::Token);
@@ -134,6 +135,32 @@ impl<'a> dc::Environment for ConfigEnvironment<'a> {
     }
 }
 
+/// Information about a Vault token.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct TokenInfo {
+    /// The actual token.
+    token: String,
+
+    /// The policies which were assigned to this token.
+    policies: BTreeSet<String>,
+
+    /// When does this expire?
+    #[serde(with = "seconds_since_epoch")]
+    expires: SystemTime,
+}
+
+impl TokenInfo {
+    /// We want to renew a token if less than half the desired TTL is remaining.
+    fn should_renew(
+        &self,
+        desired_policies: &BTreeSet<String>,
+        desired_ttl: Duration,
+    ) -> bool {
+        &self.policies != desired_policies
+            || SystemTime::now() + desired_ttl / 2 >= self.expires
+    }
+}
+
 /// An abstract interface to Vault's token-generation capabilities.  We use
 /// this to mock vault during tests.
 trait GenerateToken: Debug + Sync {
@@ -143,58 +170,9 @@ trait GenerateToken: Debug + Sync {
     fn generate_token(
         &self,
         display_name: &str,
-        policies: Vec<String>,
-        ttl: VaultDuration,
-    ) -> Result<String>;
-}
-
-/// A list of calls made to a `MockVault` instance.
-#[cfg(test)]
-type MockVaultCalls = Arc<RwLock<Vec<(String, Vec<String>, VaultDuration)>>>;
-
-/// A fake interface to vault for testing purposes.
-#[derive(Debug)]
-#[cfg(test)]
-struct MockVault {
-    /// The tokens we were asked to generate.  We store these in a RwLock
-    /// so that we can have "interior" mutability, because we don't want
-    /// `generate_token` to be `&mut self` in the general case.
-    calls: MockVaultCalls,
-}
-
-#[cfg(test)]
-impl MockVault {
-    /// Create a new MockVault.
-    fn new() -> MockVault {
-        MockVault {
-            calls: Arc::new(RwLock::new(vec![])),
-        }
-    }
-
-    /// Return a reference to record of calls made to our vault.
-    fn calls(&self) -> MockVaultCalls {
-        self.calls.clone()
-    }
-}
-
-#[cfg(test)]
-impl GenerateToken for MockVault {
-    fn addr(&self) -> &str {
-        "http://example.com:8200/"
-    }
-
-    fn generate_token(
-        &self,
-        display_name: &str,
-        policies: Vec<String>,
-        ttl: VaultDuration,
-    ) -> Result<String> {
-        self.calls
-            .write()
-            .unwrap()
-            .push((display_name.to_owned(), policies, ttl));
-        Ok("fake_token".to_owned())
-    }
+        policies: &BTreeSet<String>,
+        ttl: Duration,
+    ) -> Result<TokenInfo>;
 }
 
 /// An interface to an actual vault server.
@@ -235,9 +213,9 @@ impl GenerateToken for Vault {
     fn generate_token(
         &self,
         display_name: &str,
-        policies: Vec<String>,
-        ttl: VaultDuration,
-    ) -> Result<String> {
+        policies: &BTreeSet<String>,
+        ttl: Duration,
+    ) -> Result<TokenInfo> {
         let mkerr = || ErrorKind::VaultError(self.addr.clone());
 
         // We can't store `client` in `self`, because it has some obnoxious
@@ -250,10 +228,143 @@ impl GenerateToken for Vault {
         let opts = vault::client::TokenOptions::default()
             .display_name(display_name)
             .renewable(true)
-            .ttl(ttl)
-            .policies(policies);
+            .ttl(VaultDuration(ttl))
+            .policies(policies.clone());
         let auth = client.create_token(&opts).chain_err(&mkerr)?;
-        Ok(auth.client_token)
+        let lease_duration = auth
+            .lease_duration
+            .map_or_else(|| Duration::from_secs(30 * 24 * 60 * 60), |d| d.0);
+        let expires = SystemTime::now() + lease_duration;
+        Ok(TokenInfo {
+            token: auth.client_token,
+            // We use the passed-in policies, not `auth.policies`, just in case
+            // Vault hands out a different list than we expected.
+            policies: policies.to_owned(),
+            expires,
+        })
+    }
+}
+
+/// Map the services in a pod to their `TokenInfo`.
+type CachedPodTokens = BTreeMap<String, TokenInfo>;
+
+/// Map the pods in an environment to their `TokenCachePod`.
+type CachedTargetTokens = BTreeMap<String, CachedPodTokens>;
+
+/// A cache of Vault tokens. This format is stored on disk between runs.
+#[derive(Default, Deserialize, Serialize)]
+struct CachedTokens {
+    /// Cached token information, keyed by target, pod and service.
+    targets: BTreeMap<String, CachedTargetTokens>,
+}
+
+impl CachedTokens {
+    /// Look up an entry in our cache. An `Entry` is a Rust API that allows to
+    /// check whether an item is present in a hash table, get it, and set it.
+    fn entry(
+        &mut self,
+        target: String,
+        pod: String,
+        service: String,
+    ) -> Entry<String, TokenInfo> {
+        self.targets
+            .entry(target)
+            .or_default()
+            .entry(pod)
+            .or_default()
+            .entry(service)
+    }
+}
+
+/// A token cache which wraps `GenerateToken`, and keeps a cache of generated
+/// tokens.
+struct TokenCache<'gen> {
+    /// The generator we use to create new tokens when needed.
+    generator: &'gen dyn GenerateToken,
+
+    /// The path to our cache.
+    cache_path: PathBuf,
+
+    /// Our cache of known tokens, some of which may have expired.
+    cached: CachedTokens,
+}
+
+impl<'gen> TokenCache<'gen> {
+    /// Create a new `TokenCache` object for `project`, loading any existing
+    /// tokens from disk.
+    fn load_or_create(
+        project: &Project,
+        pod: &Pod,
+        generator: &'gen dyn GenerateToken,
+    ) -> Result<TokenCache<'gen>> {
+        let cache_path = project
+            .output_dir()
+            .join("vault-cache")
+            // We have to cache per-pod because our plugin is called in parallel.
+            .join(format!("{}.yml", pod.name()));
+        let cached = if cache_path.exists() {
+            load_yaml(&cache_path)?
+        } else {
+            CachedTokens::default()
+        };
+        Ok(TokenCache {
+            generator,
+            cache_path,
+            cached,
+        })
+    }
+
+    /// Write our token cache to disk.
+    fn save(&self) -> Result<()> {
+        dump_yaml(&self.cache_path, &self.cached)
+    }
+
+    /// Fetch a token from our cache, or generate a new one.
+    fn get<'cache>(
+        &'cache mut self,
+        project: &str,
+        target: &str,
+        pod: &str,
+        service: &str,
+        policies: &BTreeSet<String>,
+        ttl: Duration,
+    ) -> Result<&'cache TokenInfo> {
+        // Helper functions used in several places below.
+        let display_name = || format!("{}_{}_{}_{}", project, target, pod, service);
+        let mkerr = || format!("could not generate token for '{}'", service);
+
+        // Look up what we have in the cache and decide what to do.
+        let entry =
+            self.cached
+                .entry(target.to_owned(), pod.to_owned(), service.to_owned());
+        match entry {
+            Entry::Vacant(vacancy) => {
+                trace!("token cache does not contain {}", service);
+                // We can't easily factor out any code using `self.generator`
+                // while `entry` holds a mutable reference to `self.cached`,
+                // because those two parts of object are currently "owned" by
+                // different pieces of code, and Rust needs to be able to see
+                // everything that's going on.
+                let info = self
+                    .generator
+                    .generate_token(&display_name(), policies, ttl)
+                    .chain_err(mkerr)?;
+                Ok(vacancy.insert(info))
+            }
+            Entry::Occupied(occupied) => {
+                trace!("token cache hit for {}", service);
+                let cached = occupied.into_mut();
+                if cached.should_renew(&policies, ttl) {
+                    trace!("token cache needs new token for {}", service);
+                    // We'll need a new token.
+                    *cached = self
+                        .generator
+                        .generate_token(&display_name(), policies, ttl)
+                        .chain_err(mkerr)?;
+                }
+                Ok(cached)
+            }
+        }
     }
 }
 
@@ -351,6 +462,10 @@ impl PluginTransform for Plugin {
             return Ok(());
         }
 
+        // Set up our token cache.
+        let mut cache =
+            TokenCache::load_or_create(&ctx.project, &ctx.pod, generator.as_ref())?;
+
         // Apply to each service.
         for (name, service) in &mut file.services {
             // Set up a ConfigEnvironment that we can use to perform
@@ -390,10 +505,10 @@ impl PluginTransform for Plugin {
             }
 
             // Interpolate the variables found in our policy patterns.
-            let mut policies = vec![];
+            let mut policies = BTreeSet::new();
             for result in raw_policies.iter().map(|p| interpolated(p)) {
                 // We'd like to use std::result::fold here but it's unstable.
-                policies.push(result?);
+                policies.insert(result?);
             }
             debug!(
                 "Generating token for '{}' with policies {:?}",
@@ -406,20 +521,18 @@ impl PluginTransform for Plugin {
                 .insert("VAULT_ADDR".to_owned(), dc::escape(generator.addr())?);
 
             // Generate a VAULT_TOKEN.
-            let display_name = format!(
-                "{}_{}_{}_{}",
+            let ttl = Duration::from_secs(config.default_ttl);
+            let token_info = cache.get(
                 ctx.project.name(),
                 ctx.project.current_target().name(),
                 ctx.pod.name(),
-                name
-            );
-            let ttl = VaultDuration::seconds(config.default_ttl);
-            let token = generator
-                .generate_token(&display_name, policies, ttl)
-                .chain_err(|| format!("could not generate token for '{}'", name))?;
+                name,
+                &policies,
+                ttl,
+            )?;
             service
                 .environment
-                .insert("VAULT_TOKEN".to_owned(), dc::escape(token)?);
+                .insert("VAULT_TOKEN".to_owned(), dc::escape(&token_info.token)?);
 
             // Add in any extra environment variables.
             for (var, val) in &config.extra_environment {
@@ -428,86 +541,187 @@ impl PluginTransform for Plugin {
                     .insert(var.to_owned(), dc::escape(interpolated(val)?)?);
             }
         }
+
+        // Persist our tokens.
+        cache.save()?;
+
         Ok(())
     }
 }
 
-#[test]
-fn interpolates_policies() {
-    use env_logger;
-    let _ = env_logger::try_init();
+// Put all of our tests and support code in a submodule because we're going to
+// need a lot of test infrastructure.
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::{
+        iter::FromIterator,
+        sync::{Arc, RwLock},
+    };
 
-    env::set_var("VAULT_ADDR", "http://example.com:8200/");
-    env::set_var("VAULT_MASTER_TOKEN", "fake master token");
+    /// A list of calls made to a `MockVault` instance.
+    #[cfg(test)]
+    type MockVaultCalls = Arc<RwLock<Vec<(String, BTreeSet<String>, Duration)>>>;
 
-    let mut proj = Project::from_example("vault_integration").unwrap();
-    proj.set_current_target_name("development").unwrap();
+    /// A fake interface to vault for testing purposes.
+    #[derive(Debug)]
+    #[cfg(test)]
+    struct MockVault {
+        /// The tokens we were asked to generate.  We store these in a RwLock
+        /// so that we can have "interior" mutability, because we don't want
+        /// `generate_token` to be `&mut self` in the general case.
+        calls: MockVaultCalls,
+    }
 
-    let vault = MockVault::new();
-    let calls = vault.calls();
-    let plugin = Plugin::new_with_generator(&proj, Some(vault)).unwrap();
+    #[cfg(test)]
+    impl MockVault {
+        /// Create a new MockVault.
+        fn new() -> MockVault {
+            MockVault {
+                calls: Arc::new(RwLock::new(vec![])),
+            }
+        }
 
-    // Check the frontend pod.
-    let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend, "up");
-    let mut file = frontend.merged_file(proj.current_target()).unwrap();
-    plugin
-        .transform(Operation::Output, &ctx, &mut file)
-        .unwrap();
-    let web = file.services.get("web").unwrap();
-    let vault_addr = web.environment.get("VAULT_ADDR").expect("has VAULT_ADDR");
-    assert_eq!(vault_addr.value().unwrap(), "http://example.com:8200/");
-    let vault_token = web.environment.get("VAULT_TOKEN").expect("has VAULT_TOKEN");
-    assert_eq!(vault_token.value().unwrap(), "fake_token");
-    let vault_env = web.environment.get("VAULT_ENV").expect("has VAULT_ENV");
-    assert_eq!(vault_env.value().unwrap(), "development");
+        /// Return a reference to record of calls made to our vault.
+        fn calls(&self) -> MockVaultCalls {
+            self.calls.clone()
+        }
+    }
 
-    // Check the db pod to make sure no tokens are assigned.
-    let db = proj.pod("db").unwrap();
-    let ctx = plugins::Context::new(&proj, db, "up");
-    let mut file = db.merged_file(proj.current_target()).unwrap();
-    plugin
-        .transform(Operation::Output, &ctx, &mut file)
-        .unwrap();
-    let dbs = file.services.get("db").unwrap();
-    assert!(dbs.environment.get("VAULT_ADDR").is_none());
-    assert!(dbs.environment.get("VAULT_TOKEN").is_none());
-    assert!(dbs.environment.get("VAULT_ENV").is_none());
+    #[cfg(test)]
+    impl GenerateToken for MockVault {
+        fn addr(&self) -> &str {
+            "http://example.com:8200/"
+        }
 
-    // Check the calls made to vault.
-    let calls = calls.read().unwrap();
-    assert_eq!(calls.len(), 1);
-    let (ref display_name, ref policies, ref ttl) = calls[0];
-    assert_eq!(display_name, "vault_integration_development_frontend_web");
-    assert_eq!(
-        policies,
-        &[
-            "vault_integration-development".to_owned(),
-            "vault_integration-development-frontend-web".to_owned(),
-            "vault_integration-development-ssl".to_owned()
-        ]
-    );
-    assert_eq!(ttl, &VaultDuration::seconds(2592000));
-}
+        fn generate_token(
+            &self,
+            display_name: &str,
+            policies: &BTreeSet<String>,
+            ttl: Duration,
+        ) -> Result<TokenInfo> {
+            self.calls.write().unwrap().push((
+                display_name.to_owned(),
+                policies.to_owned(),
+                ttl,
+            ));
+            Ok(TokenInfo {
+                token: "fake_token".to_owned(),
+                policies: policies.to_owned(),
+                expires: SystemTime::now() + ttl,
+            })
+        }
+    }
 
-#[test]
-fn only_applied_in_specified_targets() {
-    use env_logger;
-    let _ = env_logger::try_init();
+    #[test]
+    fn do_not_renew_token_if_policies_and_ttl_are_fine() {
+        let desired_policies = BTreeSet::from_iter(vec!["a".to_owned()]);
+        let token_info = TokenInfo {
+            token: "placeholder".to_owned(),
+            policies: desired_policies.clone(),
+            expires: SystemTime::now() + Duration::from_secs(60),
+        };
+        assert!(!token_info.should_renew(&desired_policies, Duration::from_secs(60)));
+    }
 
-    let mut proj = Project::from_example("vault_integration").unwrap();
-    proj.set_current_target_name("test").unwrap();
-    let target = proj.current_target();
+    #[test]
+    fn renew_token_if_policies_do_not_match() {
+        let desired_policies = BTreeSet::from_iter(vec!["a".to_owned()]);
+        let token_info = TokenInfo {
+            token: "placeholder".to_owned(),
+            policies: BTreeSet::from_iter(vec!["b".to_owned()]),
+            expires: SystemTime::now() + Duration::from_secs(60),
+        };
+        assert!(token_info.should_renew(&desired_policies, Duration::from_secs(60)));
+    }
 
-    let vault = MockVault::new();
-    let plugin = Plugin::new_with_generator(&proj, Some(vault)).unwrap();
+    #[test]
+    fn renew_token_if_half_of_ttl_expired() {
+        let desired_policies = BTreeSet::from_iter(vec!["a".to_owned()]);
+        let token_info = TokenInfo {
+            token: "placeholder".to_owned(),
+            policies: desired_policies.clone(),
+            expires: SystemTime::now() + Duration::from_secs(29),
+        };
+        assert!(token_info.should_renew(&desired_policies, Duration::from_secs(60)));
+    }
 
-    let frontend = proj.pod("frontend").unwrap();
-    let ctx = plugins::Context::new(&proj, frontend, "test");
-    let mut file = frontend.merged_file(target).unwrap();
-    plugin
-        .transform(Operation::Output, &ctx, &mut file)
-        .unwrap();
-    let web = file.services.get("web").unwrap();
-    assert_eq!(web.environment.get("VAULT_ADDR"), None);
+    #[test]
+    fn interpolates_policies() {
+        let _ = env_logger::try_init();
+
+        env::set_var("VAULT_ADDR", "http://example.com:8200/");
+        env::set_var("VAULT_MASTER_TOKEN", "fake master token");
+
+        let mut proj = Project::from_example("vault_integration").unwrap();
+        proj.set_current_target_name("development").unwrap();
+
+        let vault = MockVault::new();
+        let calls = vault.calls();
+        let plugin = Plugin::new_with_generator(&proj, Some(vault)).unwrap();
+
+        // Check the frontend pod.
+        let frontend = proj.pod("frontend").unwrap();
+        let ctx = plugins::Context::new(&proj, frontend, "up");
+        let mut file = frontend.merged_file(proj.current_target()).unwrap();
+        plugin
+            .transform(Operation::Output, &ctx, &mut file)
+            .unwrap();
+        let web = file.services.get("web").unwrap();
+        let vault_addr = web.environment.get("VAULT_ADDR").expect("has VAULT_ADDR");
+        assert_eq!(vault_addr.value().unwrap(), "http://example.com:8200/");
+        let vault_token = web.environment.get("VAULT_TOKEN").expect("has VAULT_TOKEN");
+        assert_eq!(vault_token.value().unwrap(), "fake_token");
+        let vault_env = web.environment.get("VAULT_ENV").expect("has VAULT_ENV");
+        assert_eq!(vault_env.value().unwrap(), "development");
+
+        // Check the db pod to make sure no tokens are assigned.
+        let db = proj.pod("db").unwrap();
+        let ctx = plugins::Context::new(&proj, db, "up");
+        let mut file = db.merged_file(proj.current_target()).unwrap();
+        plugin
+            .transform(Operation::Output, &ctx, &mut file)
+            .unwrap();
+        let dbs = file.services.get("db").unwrap();
+        assert!(dbs.environment.get("VAULT_ADDR").is_none());
+        assert!(dbs.environment.get("VAULT_TOKEN").is_none());
+        assert!(dbs.environment.get("VAULT_ENV").is_none());
+
+        // Check the calls made to vault.
+        let calls = calls.read().unwrap();
+        assert_eq!(calls.len(), 1);
+        let (ref display_name, ref policies, ref ttl) = calls[0];
+        assert_eq!(display_name, "vault_integration_development_frontend_web");
+        assert_eq!(
+            policies,
+            &BTreeSet::from_iter(vec![
+                "vault_integration-development".to_owned(),
+                "vault_integration-development-frontend-web".to_owned(),
+                "vault_integration-development-ssl".to_owned()
+            ])
+        );
+        assert_eq!(ttl, &Duration::from_secs(2592000));
+    }
+
+    #[test]
+    fn only_applied_in_specified_targets() {
+        use env_logger;
+        let _ = env_logger::try_init();
+
+        let mut proj = Project::from_example("vault_integration").unwrap();
+        proj.set_current_target_name("test").unwrap();
+        let target = proj.current_target();
+
+        let vault = MockVault::new();
+        let plugin = Plugin::new_with_generator(&proj, Some(vault)).unwrap();
+
+        let frontend = proj.pod("frontend").unwrap();
+        let ctx = plugins::Context::new(&proj, frontend, "test");
+        let mut file = frontend.merged_file(target).unwrap();
+        plugin
+            .transform(Operation::Output, &ctx, &mut file)
+            .unwrap();
+        let web = file.services.get("web").unwrap();
+        assert_eq!(web.environment.get("VAULT_ADDR"), None);
+    }
 }

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -509,7 +509,6 @@ impl<'a> Iterator for AllFiles<'a> {
 #[test]
 fn pods_are_normalized_on_load() {
     use crate::project::Project;
-    use env_logger;
     let _ = env_logger::try_init();
 
     let proj = Project::from_example("hello").unwrap();
@@ -537,7 +536,6 @@ fn pods_are_normalized_on_load() {
 
 #[test]
 fn can_merge_base_file_and_target() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj: Project = Project::from_example("hello").unwrap();
     let target = proj.target("development").unwrap();
@@ -549,7 +547,6 @@ fn can_merge_base_file_and_target() {
 
 #[test]
 fn pod_type_returns_type_of_pod() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj: Project = Project::from_example("rails_hello").unwrap();
     let frontend = proj.pod("frontend").unwrap();

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -16,6 +16,7 @@ use crate::ext::context::ContextExt;
 use crate::ext::git_url::GitUrlExt;
 use crate::ext::service::ServiceExt;
 use crate::pod::Pod;
+#[cfg(test)]
 use crate::project::Project;
 use crate::serde_helpers::{dump_yaml, load_yaml};
 use crate::util::ConductorPathExt;
@@ -36,6 +37,21 @@ struct SourceConfig {
     /// `docker-compose.yml` files, and that's what our `compose_yml`
     /// library supports.
     context: dc::RawOr<dc::Context>,
+}
+
+/// Project-related directories needed by `sources`.
+///
+/// We break these out into their own struct so that `Sources` doesn't need to
+/// depend on `Project`, which makes the borrow-checker much happier.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct SourcesDirs {
+    /// The `src/` directory associated with the project, for resolving paths to
+    /// sources stored in external repositories.
+    pub src_dir: PathBuf,
+    /// The `pods/` directory associated with the project, for resolving paths
+    /// to sources stored in the base repo.
+    pub pods_dir: PathBuf,
 }
 
 /// All the source trees associated with a project's Docker images.
@@ -60,7 +76,7 @@ impl Sources {
         let alias = context.human_alias()?;
 
         // Look up whether we've mounted this container or not.
-        let mounted = mounted_sources.get(&alias).cloned().unwrap_or(true);
+        let mounted = mounted_sources.get(&alias).cloned().unwrap_or(false);
 
         // Build our Source object. If two services share a git repo but
         // use different subdirectories, we only create a single Source
@@ -169,9 +185,23 @@ impl Sources {
     /// `config/sources.yml` and with service labels of the form
     /// `io.fdy.cage.lib.<KEY>`.
     pub fn find_by_lib_key(&self, lib_key: &str) -> Option<&Source> {
-        self.lib_keys
-            .get(lib_key)
-            .and_then(|alias| self.find_by_alias(alias))
+        match self.lib_keys.get(lib_key) {
+            Some(alias) => self.find_by_alias(&alias),
+            None => None,
+        }
+    }
+
+    /// Look up a source tree using a "lib key", which is key used in
+    /// `config/sources.yml` and with service labels of the form
+    /// `io.fdy.cage.lib.<KEY>`.
+    pub fn find_by_lib_key_mut(&mut self, lib_key: &str) -> Option<&mut Source> {
+        match self.lib_keys.get(lib_key) {
+            Some(alias) => {
+                let alias = alias.to_owned();
+                self.find_by_alias_mut(&alias)
+            }
+            None => None,
+        }
     }
 
     /// Save any state that we want to persist until the next run.
@@ -179,7 +209,7 @@ impl Sources {
         let mut mounted = BTreeMap::new();
         for source in self.iter() {
             // Only record non-default mount values.
-            if !source.mounted() {
+            if source.mounted() {
                 mounted.insert(source.alias(), source.mounted());
             }
         }
@@ -249,31 +279,33 @@ impl Source {
     ///
     /// The `project` argument is mandatory because we can't store a pointer
     /// to it without creating a circular reference loop.
-    pub fn path(&self, project: &Project) -> PathBuf {
+    pub fn path(&self, dirs: &SourcesDirs) -> PathBuf {
         match self.context {
-            dc::Context::GitUrl(_) => project.src_dir().join(Path::new(self.alias())),
-            dc::Context::Dir(ref path) => project.pods_dir().join(path),
+            dc::Context::GitUrl(_) => dirs.src_dir.join(Path::new(self.alias())),
+            dc::Context::Dir(ref path) => dirs.pods_dir.join(path),
         }
     }
 
     /// Has this project been cloned locally?
-    pub fn is_available_locally(&self, project: &Project) -> bool {
-        self.path(project).exists()
+    pub fn is_available_locally(&self, dirs: &SourcesDirs) -> bool {
+        self.path(dirs).exists()
     }
 
     /// Clone the source code of this repository using git.
-    pub fn clone_source<CR>(&self, runner: &CR, project: &Project) -> Result<()>
+    pub fn clone_source<CR>(&mut self, runner: &CR, dirs: &SourcesDirs) -> Result<()>
     where
         CR: CommandRunner,
     {
         if let dc::Context::GitUrl(ref git_url) = self.context {
-            let dest = self.path(project).with_guaranteed_parent()?;
+            let dest = self.path(dirs).with_guaranteed_parent()?;
             runner
                 .build("git")
                 .arg("clone")
                 .args(&git_url.clone_args()?)
                 .arg(&dest)
-                .exec()
+                .exec()?;
+            self.set_mounted(true);
+            Ok(())
         } else {
             Err(format!("'{}' is not a git repository", &self.context).into())
         }
@@ -282,15 +314,15 @@ impl Source {
     /// (Test mode only.) Pretend to clone the source code for this
     /// repository by creating an empty directory in the right place.
     #[cfg(test)]
-    pub fn fake_clone_source(&self, project: &Project) -> Result<()> {
-        fs::create_dir_all(self.path(project))?;
+    pub fn fake_clone_source(&mut self, dirs: &SourcesDirs) -> Result<()> {
+        fs::create_dir_all(self.path(dirs))?;
+        self.set_mounted(true);
         Ok(())
     }
 }
 
 #[test]
 fn are_loaded_with_projects() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("hello").unwrap();
     let sources = proj.sources();
@@ -302,14 +334,13 @@ fn are_loaded_with_projects() {
     let url = "https://github.com/docker/dockercloud-hello-world.git";
     assert_eq!(hello.context(), &dc::Context::new(url));
     assert_eq!(
-        hello.path(&proj),
+        hello.path(&proj.sources_dirs()),
         proj.src_dir().join("dockercloud-hello-world")
     );
 }
 
 #[test]
 fn are_loaded_from_config_sources_yml() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("rails_hello").unwrap();
     let sources = proj.sources();
@@ -321,60 +352,62 @@ fn are_loaded_from_config_sources_yml() {
         lib.context(),
         &dc::Context::new("https://github.com/rails/coffee-rails.git")
     );
-    assert_eq!(lib.path(&proj), proj.src_dir().join("coffee-rails"));
+    assert_eq!(
+        lib.path(&proj.sources_dirs()),
+        proj.src_dir().join("coffee-rails")
+    );
 }
 
 #[test]
 fn rejects_libs_with_subdirectories() {
-    use env_logger;
     let _ = env_logger::try_init();
     assert!(Project::from_fixture("with_lib_subdir").is_err())
 }
 
 #[test]
 fn can_be_cloned() {
-    use env_logger;
     let _ = env_logger::try_init();
-    let proj = Project::from_example("hello").unwrap();
+    let mut proj = Project::from_example("hello").unwrap();
+    let sources_dirs = proj.sources_dirs();
     let source = proj
-        .sources()
-        .find_by_alias("dockercloud-hello-world")
+        .sources_mut()
+        .find_by_alias_mut("dockercloud-hello-world")
         .unwrap();
     let runner = TestCommandRunner::new();
-    source.clone_source(&runner, &proj).unwrap();
+    source.clone_source(&runner, &sources_dirs).unwrap();
     let url = "https://github.com/docker/dockercloud-hello-world.git";
-    assert_ran!(runner, { ["git", "clone", url, source.path(&proj)] });
+    assert_ran!(runner, {
+        ["git", "clone", url, source.path(&sources_dirs)]
+    });
     proj.remove_test_output().unwrap();
 }
 
 #[test]
 fn can_be_checked_to_see_if_cloned() {
-    use env_logger;
     let _ = env_logger::try_init();
-    let proj = Project::from_example("hello").unwrap();
+    let mut proj = Project::from_example("hello").unwrap();
+    let sources_dirs = proj.sources_dirs();
     let source = proj
-        .sources()
-        .find_by_alias("dockercloud-hello-world")
+        .sources_mut()
+        .find_by_alias_mut("dockercloud-hello-world")
         .unwrap();
-    assert!(!source.is_available_locally(&proj));
-    source.fake_clone_source(&proj).unwrap();
-    assert!(source.is_available_locally(&proj));
+    assert!(!source.is_available_locally(&sources_dirs));
+    source.fake_clone_source(&sources_dirs).unwrap();
+    assert!(source.is_available_locally(&sources_dirs));
     proj.remove_test_output().unwrap();
 }
 
 #[test]
 fn dir_context_is_always_available_locally() {
-    use env_logger;
     let _ = env_logger::try_init();
     let proj = Project::from_example("node_hello").unwrap();
     let source = proj.sources().find_by_alias("node_hello").unwrap();
-    assert!(source.is_available_locally(&proj));
+    assert!(source.is_available_locally(&proj.sources_dirs()));
     proj.remove_test_output().unwrap();
 }
 
 #[test]
 fn mounted_state_is_saved_between_runs() {
-    use env_logger;
     let _ = env_logger::try_init();
     use rand::random;
     let id: u16 = random();
@@ -385,9 +418,9 @@ fn mounted_state_is_saved_between_runs() {
         {
             let sources = proj.sources_mut();
             let source = sources.find_by_alias_mut("node_hello").unwrap();
-            assert_eq!(source.mounted(), true);
-            source.set_mounted(false);
             assert_eq!(source.mounted(), false);
+            source.set_mounted(true);
+            assert_eq!(source.mounted(), true);
         }
         proj.save_settings().unwrap();
     }
@@ -395,6 +428,6 @@ fn mounted_state_is_saved_between_runs() {
     // Reload the project and make sure the value was saved.
     let proj = Project::from_example_and_random_id("node_hello", id).unwrap();
     let source = proj.sources().find_by_alias("node_hello").unwrap();
-    assert_eq!(source.mounted(), false);
+    assert_eq!(source.mounted(), true);
     proj.remove_test_output().unwrap();
 }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -166,6 +166,13 @@ impl Sources {
         }
     }
 
+    /// Iterate over all source trees associated with this project.
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
+        IterMut {
+            iter: self.sources.iter_mut(),
+        }
+    }
+
     /// Look up a source tree using the short-form local alias.
     pub fn find_by_alias(&self, alias: &str) -> Option<&Source> {
         self.sources.get(alias)
@@ -232,6 +239,22 @@ impl<'a> Iterator for Iter<'a> {
     type Item = &'a Source;
 
     fn next(&mut self) -> Option<&'a Source> {
+        self.iter.next().map(|(_alias, source)| source)
+    }
+}
+
+/// A mutable iterator over all source trees associated with this project.
+#[allow(missing_debug_implementations)]
+pub struct IterMut<'a> {
+    /// Our wrapped iterator.  We wrap this in our own struct to make the
+    /// underlying type opaque.
+    iter: btree_map::IterMut<'a, String, Source>,
+}
+
+impl<'a> Iterator for IterMut<'a> {
+    type Item = &'a mut Source;
+
+    fn next(&mut self) -> Option<&'a mut Source> {
         self.iter.next().map(|(_alias, source)| source)
     }
 }


### PR DESCRIPTION
This PR contains multiple, unrelated patches that are intended to make monorepo-style development more pleasant with cage, including:

- Sources are no longer mounted by default just because they're present on the filesystem.
- `cage source unmount --all` is finally supported, 4 years after it was proposed.
- We now support Vault much better in development mode, thanks to a local token cache. Tokens are fetched in parallel, and the cache is automatically refreshed whenever TTLs are below 50% of their initial life.