### PR TITLE
add `down` as an alias for `stop`

### DIFF
--- a/src/cli.yml
+++ b/src/cli.yml
@@ -89,6 +89,10 @@ subcommands:
       about: "Stop all containers associated with this project"
       args:
         - POD_OR_SERVICE: *pod_or_service
+  - down:
+      about: "Stop all containers associated with this project. Alias for `stop`."
+      args:
+        - POD_OR_SERVICE: *pod_or_service
   - rm:
       about: "Remove the containers associated with a pod or service"
       args:

--- a/src/command_runner.rs
+++ b/src/command_runner.rs
@@ -24,7 +24,7 @@ pub trait CommandRunner {
 /// A stripped down interface based on `std::process::Command`.  We use
 /// this so we can mock out shell commands during tests.
 pub trait Command {
-    /// Add an arugment to our command.
+    /// Add an argument to our command.
     fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self;
 
     /// Add several arguments to our command.

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,7 +277,7 @@ fn run(matches: &clap::ArgMatches<'_>) -> Result<()> {
             let opts = cage::args::opts::Empty;
             proj.compose(&runner, "restart", &acts_on, &opts)?;
         }
-        "stop" => {
+        "stop" | "down" => {
             let acts_on = sc_matches.to_acts_on("POD_OR_SERVICE", false);
             let opts = cage::args::opts::Empty;
             proj.compose(&runner, "stop", &acts_on, &opts)?;


### PR DESCRIPTION
since `cage` uses the verb `up` to start a pod / service / etc, it makes sense that you can `cage down` instead of having to `cage stop` them.